### PR TITLE
Fix image and font fallbacks

### DIFF
--- a/src/Dto/Workbox.php
+++ b/src/Dto/Workbox.php
@@ -34,10 +34,10 @@ final class Workbox
     public null|Url $pageFallback = null;
 
     #[SerializedName('image_fallback')]
-    public null|Url $imageFallback = null;
+    public null|Asset $imageFallback = null;
 
     #[SerializedName('font_fallback')]
-    public null|Url $fontFallback = null;
+    public null|Asset $fontFallback = null;
 
     /**
      * @var array<Url>


### PR DESCRIPTION
Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

The image and font fallback should be of type Asset and not URL