### PR TITLE
require ext-imagick

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     },
     "require": {
         "php": ">=8.2",
+        "ext-imagick": "*",
         "phpdocumentor/reflection-docblock": "^5.3",
         "symfony/asset-mapper": "^6.4|^7.0",
         "symfony/config": "^6.4|^7.0",


### PR DESCRIPTION
Since we have a hard dependency on imagick, we should require it.

