### PR TITLE
Add documentation so that pwa: commands work

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Install the bundle with Composer:
 composer require spomky-labs/pwa-bundle
 ```
 
+If you want to use the commands to generate icons and screenshots, install the necessary dependencies:
+
+```bash
+composer require symfony/panther symfony/mime symfony/filesystem --dev
+bin/console pwa:create:icons --help
+```
+
 This project follows the [semantic versioning](http://semver.org/) strictly.
 
 # Documentation

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ composer require spomky-labs/pwa-bundle
 If you want to use the commands to generate icons and screenshots, install the necessary dependencies:
 
 ```bash
-composer require symfony/panther symfony/mime symfony/filesystem --dev
+composer require symfony/panther dbrekelmans/bdi symfony/mime symfony/filesystem --dev
+vendor/bin/bdi detect drivers
 bin/console pwa:create:icons --help
 ```
 


### PR DESCRIPTION
I thought the commands were gone!  But they're not even visible if the dependencies aren't installed.

Another approach would be to register the command, but not allow it to run without the dependencies, and simply tell the user what they need to install.

I can make a PR for that if you want.