### PR TITLE
Remove ImportMapConfigReader dependency from PwaRuntime

### DIFF
--- a/src/Twig/PwaRuntime.php
+++ b/src/Twig/PwaRuntime.php
@@ -8,7 +8,6 @@ use InvalidArgumentException;
 use SpomkyLabs\PwaBundle\Dto\Icon;
 use SpomkyLabs\PwaBundle\Dto\Manifest;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
-use Symfony\Component\AssetMapper\ImportMap\ImportMapConfigReader;
 use Symfony\Component\AssetMapper\MappedAsset;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Mime\MimeTypes;

--- a/src/Twig/PwaRuntime.php
+++ b/src/Twig/PwaRuntime.php
@@ -25,8 +25,6 @@ final readonly class PwaRuntime
         private bool $manifestEnabled,
         #[Autowire('%spomky_labs_pwa.sw.enabled%')]
         private bool $serviceWorkerEnabled,
-        #[Autowire('@asset_mapper.importmap.config_reader')]
-        private ImportMapConfigReader $importMapConfigReader,
         private AssetMapperInterface $assetMapper,
         private Manifest $manifest,
         #[Autowire('%spomky_labs_pwa.manifest.public_url%')]
@@ -94,8 +92,7 @@ final readonly class PwaRuntime
             $registerOptions = sprintf(', {%s}', mb_substr($registerOptions, 2));
         }
         if ($serviceWorker->workbox->enabled === true) {
-            $hasWorkboxWindow = $this->importMapConfigReader->findRootImportMapEntry('workbox-window') !== null;
-            $workboxUrl = $hasWorkboxWindow ? 'workbox-window' : 'https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox-window.prod.mjs';
+            $workboxUrl = sprintf('%s%s', $serviceWorker->workbox->workboxPublicUrl, '/workbox-window.prod.mjs');
             $declaration = <<<SERVICE_WORKER
 <script type="module" {$scriptAttributes}>
   import {Workbox} from '{$workboxUrl}';


### PR DESCRIPTION
The dependency on ImportMapConfigReader has been removed from PwaRuntime code to simplify Workbox URL generation. The URL is now directly derived from the `workboxPublicUrl` property of the serviceWorker's workbox object. This makes the code more maintainable and easy to read.

Target branch: 1.1.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
