### PR TITLE
Remove service worker file from src/Resources

### DIFF
--- a/src/Resources/sw-skeleton.js
+++ b/src/Resources/sw-skeleton.js
@@ -1,6 +1,0 @@
-// *** Service Worker *** //
-/*
-    This is the service worker file. It will be populated with the rules you define in the
-    configuration file.
-    You can define here custom rules depending on your application needs.
- */


### PR DESCRIPTION
The 'sw-skeleton.js' file, previously located in src/Resources, has been deleted. This was a redundant file containing service worker rules, which are no longer necessary for our application's needs.

Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
