### PR TITLE
Add missing 'preferRelatedApplications' attribute to Manifest Dto

### DIFF
--- a/src/Dto/Manifest.php
+++ b/src/Dto/Manifest.php
@@ -96,6 +96,9 @@ final class Manifest
     #[SerializedName('related_applications')]
     public array $relatedApplications = [];
 
+    #[SerializedName('prefer_related_applications')]
+    public bool $preferRelatedApplications = false;
+
     /**
      * @var array<Shortcut>
      */


### PR DESCRIPTION
Added missing attribute 'preferRelatedApplications' to the Manifest data transfer object (Dto). This boolean property defaults to false and indicates whether applications listed under 'relatedApplications' should be preferred over the browser.

Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
