### PR TITLE
Add support for custom user agent in screenshot generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "twig/twig": "^3.8"
     },
     "require-dev": {
+        "ext-sockets": "*",
         "dbrekelmans/bdi": "^1.1",
         "infection/infection": "^0.28",
         "phpstan/extension-installer": "^1.1",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -107,7 +107,22 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
+			count: 2
+			path: src/Command/CreateScreenshotCommand.php
+
+		-
+			message: "#^Method SpomkyLabs\\\\PwaBundle\\\\Command\\\\CreateScreenshotCommand\\:\\:getDefaultArguments\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
+			path: src/Command/CreateScreenshotCommand.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
+			count: 1
+			path: src/Command/CreateScreenshotCommand.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 3
 			path: src/Command/CreateScreenshotCommand.php
 
 		-

--- a/src/Command/CreateScreenshotCommand.php
+++ b/src/Command/CreateScreenshotCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Mime\MimeTypes;
 use Symfony\Component\Panther\Client;
 use Symfony\Component\Yaml\Yaml;
 use Throwable;
+use function assert;
 use function count;
 
 #[AsCommand(

--- a/src/EventSubscriber/ScreenshotSubscriber.php
+++ b/src/EventSubscriber/ScreenshotSubscriber.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\EventSubscriber;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+final readonly class ScreenshotSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        #[Autowire(service: 'profiler')]
+        private ?Profiler $profiler = null,
+        #[Autowire(param: 'spomky_labs_pwa.screenshot_user_agent')]
+        private null|string $userAgent = null,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            RequestEvent::class => 'onRequest',
+        ];
+    }
+
+    public function onRequest(RequestEvent $event): void
+    {
+        if (! $event->isMainRequest() || $this->profiler === null) {
+            return;
+        }
+
+        $userAgent = $event->getRequest()
+            ->headers->get('user-agent');
+        if ($userAgent === null) {
+            return;
+        }
+        $userAgentToFind = $this->userAgent ?? 'HeadlessChrome';
+        if (! str_contains($userAgent, $userAgentToFind)) {
+            return;
+        }
+
+        $this->profiler->disable();
+    }
+}

--- a/src/Resources/config/definition/web_client.php
+++ b/src/Resources/config/definition/web_client.php
@@ -11,5 +11,11 @@ return static function (DefinitionConfigurator $definition): void {
                 ->defaultNull()
                 ->info('The Panther Client for generating screenshots. If not set, the default client will be used.')
             ->end()
+            ->scalarNode('user_agent')
+                ->defaultNull()
+                ->info(
+                    'The user agent to use when generating screenshots. If not set, the default user agent will be used. When requesting the current application in an environment other than "prod", the profiler will be disabled.'
+                )
+            ->end()
         ->end();
 };

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -12,6 +12,7 @@ use SpomkyLabs\PwaBundle\Command\ListCacheStrategiesCommand;
 use SpomkyLabs\PwaBundle\DataCollector\PwaCollector;
 use SpomkyLabs\PwaBundle\Dto\Manifest;
 use SpomkyLabs\PwaBundle\Dto\ServiceWorker;
+use SpomkyLabs\PwaBundle\EventSubscriber\ScreenshotSubscriber;
 use SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor;
 use SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor;
 use SpomkyLabs\PwaBundle\MatchCallbackHandler\MatchCallbackHandlerInterface;
@@ -142,6 +143,7 @@ return static function (ContainerConfigurator $configurator): void {
             '$urls' => abstract_arg('urls'),
         ])
     ;
+    $container->set(ScreenshotSubscriber::class);
 
     if ($configurator->env() !== 'prod') {
         $container->set(PwaCollector::class)

--- a/src/SpomkyLabsPwaBundle.php
+++ b/src/SpomkyLabsPwaBundle.php
@@ -37,6 +37,8 @@ final class SpomkyLabsPwaBundle extends AbstractBundle
         if ($config['web_client'] !== null) {
             $builder->setAlias('pwa.web_client', $config['web_client']);
         }
+        $builder->setParameter('spomky_labs_pwa.screenshot_user_agent', $config['user_agent']);
+
         $serviceWorkerConfig = $config['serviceworker'];
         $manifestConfig = $config['manifest'];
         if ($serviceWorkerConfig['enabled'] === true && $manifestConfig['enabled'] === true) {


### PR DESCRIPTION
This update includes a new service, `ScreenshotSubscriber`, that disables profiler if the user agent matches a specified one. Also, a custom user agent can now be used when using the `CreateScreenshotCommand`, and this setting is configurable in `web_client.php`. Finally, some PHPStan warnings were addressed and the "ext-sockets" package was added to the dev dependencies.

Target branch: 1.2.x
Resolves issue #147

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
