### PR TITLE
Refactor code to check if service worker is enabled

### DIFF
--- a/src/DataCollector/PwaCollector.php
+++ b/src/DataCollector/PwaCollector.php
@@ -9,7 +9,6 @@ use SpomkyLabs\PwaBundle\CachingStrategy\HasCacheStrategiesInterface;
 use SpomkyLabs\PwaBundle\Dto\Manifest;
 use SpomkyLabs\PwaBundle\Dto\ServiceWorker;
 use SpomkyLabs\PwaBundle\Dto\Workbox;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -37,8 +36,6 @@ final class PwaCollector extends DataCollector
         private readonly iterable $cachingServices,
         private readonly Manifest $manifest,
         private readonly ServiceWorker $serviceWorker,
-        #[Autowire(param: 'spomky_labs_pwa.manifest.enabled')]
-        private readonly bool $manifestEnabled,
     ) {
     }
 
@@ -57,7 +54,7 @@ final class PwaCollector extends DataCollector
         }
         $this->data['serviceWorker'] = $this->serviceWorker;
         $this->data['manifest'] = [
-            'enabled' => $this->manifestEnabled,
+            'enabled' => $this->serviceWorker->enabled,
             'data' => $this->manifest,
             'installable' => $this->isInstallable(),
             'output' => $this->serializer->serialize($this->manifest, 'json', $jsonOptions),
@@ -101,7 +98,7 @@ final class PwaCollector extends DataCollector
     private function isInstallable(): array
     {
         $reasons = [
-            'The manifest must be enabled' => ! $this->manifestEnabled,
+            'The manifest must be enabled' => ! $this->manifest->enabled,
             'The manifest must have a short name or a name' => $this->manifest->shortName === null && $this->manifest->name === null,
             'The manifest must have a start URL' => $this->manifest->startUrl === null,
             'The manifest must have a display value set to "standalone", "fullscreen" or "minimal-ui' => ! in_array(

--- a/src/Dto/Manifest.php
+++ b/src/Dto/Manifest.php
@@ -11,6 +11,8 @@ final class Manifest
 {
     use TranslatableTrait;
 
+    public bool $enabled = false;
+
     #[SerializedName('use_credentials')]
     public bool $useCredentials = true;
 

--- a/src/Service/ServiceWorkerCompiler.php
+++ b/src/Service/ServiceWorkerCompiler.php
@@ -18,8 +18,6 @@ final readonly class ServiceWorkerCompiler
      * @param iterable<ServiceWorkerRuleInterface> $serviceworkerRules
      */
     public function __construct(
-        #[Autowire('%spomky_labs_pwa.sw.enabled%')]
-        private bool $serviceWorkerEnabled,
         private ServiceWorker $serviceWorker,
         private AssetMapperInterface $assetMapper,
         #[TaggedIterator('spomky_labs_pwa.service_worker_rule', defaultPriorityMethod: 'getPriority')]
@@ -31,7 +29,7 @@ final readonly class ServiceWorkerCompiler
 
     public function compile(): ?string
     {
-        if ($this->serviceWorkerEnabled === false) {
+        if ($this->serviceWorker->enabled === false) {
             return null;
         }
         $body = '';

--- a/src/Subscriber/ManifestCompileEventListener.php
+++ b/src/Subscriber/ManifestCompileEventListener.php
@@ -34,8 +34,6 @@ final readonly class ManifestCompileEventListener
     public function __construct(
         private SerializerInterface $serializer,
         private Manifest $manifest,
-        #[Autowire('%spomky_labs_pwa.manifest.enabled%')]
-        private bool $manifestEnabled,
         #[Autowire('%spomky_labs_pwa.manifest.public_url%')]
         string $manifestPublicUrl,
         #[Autowire('@asset_mapper.local_public_assets_filesystem')]
@@ -60,7 +58,7 @@ final readonly class ManifestCompileEventListener
 
     public function __invoke(PreAssetsCompileEvent $event): void
     {
-        if (! $this->manifestEnabled) {
+        if (! $this->manifest->enabled) {
             return;
         }
         $manifest = clone $this->manifest;

--- a/src/Subscriber/PwaDevServerSubscriber.php
+++ b/src/Subscriber/PwaDevServerSubscriber.php
@@ -51,11 +51,7 @@ final readonly class PwaDevServerSubscriber implements EventSubscriberInterface
         private ServiceWorkerCompiler $serviceWorkerBuilder,
         private SerializerInterface $serializer,
         private Manifest $manifest,
-        ServiceWorker $serviceWorker,
-        #[Autowire('%spomky_labs_pwa.manifest.enabled%')]
-        private bool $manifestEnabled,
-        #[Autowire('%spomky_labs_pwa.sw.enabled%')]
-        private bool $serviceWorkerEnabled,
+        private ServiceWorker $serviceWorker,
         #[Autowire('%spomky_labs_pwa.manifest.public_url%')]
         string $manifestPublicUrl,
         private null|Profiler $profiler,
@@ -97,13 +93,13 @@ final readonly class PwaDevServerSubscriber implements EventSubscriberInterface
             ->getPathInfo();
 
         switch (true) {
-            case $this->manifestEnabled === true && $pathInfo === $this->manifestPublicUrl:
+            case $this->manifest->enabled === true && $pathInfo === $this->manifestPublicUrl:
                 $this->serveManifest($event);
                 break;
-            case $this->serviceWorkerEnabled === true && $pathInfo === $this->serviceWorkerPublicUrl:
+            case $this->serviceWorker->enabled === true && $pathInfo === $this->serviceWorkerPublicUrl:
                 $this->serveServiceWorker($event);
                 break;
-            case $this->serviceWorkerEnabled === true && $this->workboxVersion !== null && $this->workboxPublicUrl !== null && str_starts_with(
+            case $this->serviceWorker->enabled === true && $this->workboxVersion !== null && $this->workboxPublicUrl !== null && str_starts_with(
                 $pathInfo,
                 $this->workboxPublicUrl
             ):

--- a/src/Subscriber/ServiceWorkerCompileEventListener.php
+++ b/src/Subscriber/ServiceWorkerCompileEventListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\PwaBundle\Subscriber;
 
+use SpomkyLabs\PwaBundle\Dto\ServiceWorker;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerCompiler;
 use Symfony\Component\AssetMapper\Event\PreAssetsCompileEvent;
 use Symfony\Component\AssetMapper\Path\PublicAssetsFilesystemInterface;
@@ -16,9 +17,8 @@ final readonly class ServiceWorkerCompileEventListener
     private ?string $serviceWorkerPublicUrl;
 
     public function __construct(
+        private ServiceWorker $serviceWorker,
         private ServiceWorkerCompiler $serviceWorkerBuilder,
-        #[Autowire('%spomky_labs_pwa.sw.enabled%')]
-        private bool $serviceWorkerEnabled,
         #[Autowire('%spomky_labs_pwa.sw.public_url%')]
         ?string $serviceWorkerPublicUrl,
         #[Autowire('@asset_mapper.local_public_assets_filesystem')]
@@ -32,7 +32,7 @@ final readonly class ServiceWorkerCompileEventListener
 
     public function __invoke(PreAssetsCompileEvent $event): void
     {
-        if (! $this->serviceWorkerEnabled) {
+        if (! $this->serviceWorker->enabled) {
             return;
         }
         $data = $this->serviceWorkerBuilder->compile();

--- a/src/Subscriber/WorkboxCompileEventListener.php
+++ b/src/Subscriber/WorkboxCompileEventListener.php
@@ -19,8 +19,6 @@ use function is_string;
 final readonly class WorkboxCompileEventListener
 {
     public function __construct(
-        #[Autowire('%spomky_labs_pwa.sw.enabled%')]
-        private bool $serviceWorkerEnabled,
         #[Autowire('@asset_mapper.local_public_assets_filesystem')]
         private PublicAssetsFilesystemInterface $assetsFilesystem,
         private Manifest $manifest,
@@ -29,11 +27,8 @@ final readonly class WorkboxCompileEventListener
 
     public function __invoke(PreAssetsCompileEvent $event): void
     {
-        if (! $this->serviceWorkerEnabled) {
-            return;
-        }
         $serviceWorker = $this->manifest->serviceWorker;
-        if ($serviceWorker === null || $serviceWorker->workbox->enabled !== true || $serviceWorker->workbox->useCDN === true) {
+        if ($serviceWorker === null || $serviceWorker->enabled !== true || $serviceWorker->workbox->enabled !== true || $serviceWorker->workbox->useCDN === true) {
             return;
         }
         $workboxVersion = $serviceWorker->workbox->version;

--- a/src/Twig/PwaRuntime.php
+++ b/src/Twig/PwaRuntime.php
@@ -20,10 +20,6 @@ final readonly class PwaRuntime
     private string $manifestPublicUrl;
 
     public function __construct(
-        #[Autowire('%spomky_labs_pwa.manifest.enabled%')]
-        private bool $manifestEnabled,
-        #[Autowire('%spomky_labs_pwa.sw.enabled%')]
-        private bool $serviceWorkerEnabled,
         private AssetMapperInterface $assetMapper,
         private Manifest $manifest,
         #[Autowire('%spomky_labs_pwa.manifest.public_url%')]
@@ -42,10 +38,10 @@ final readonly class PwaRuntime
         array $swAttributes = []
     ): string {
         $output = '';
-        if ($this->manifestEnabled === true) {
+        if ($this->manifest->enabled === true) {
             $output = $this->injectManifestFile($output);
         }
-        if ($this->serviceWorkerEnabled === true) {
+        if ($this->manifest->serviceWorker?->enabled === true) {
             $output = $this->injectServiceWorker($output, $injectSW, $swAttributes);
         }
         $output = $this->injectIcons($output, $injectIcons);


### PR DESCRIPTION
This commit removes all properties that check if a service worker is enabled in favor of checking this directly on the service worker object itself. It affects multiple files and results in a cleaner, more object-oriented approach to determining if the service worker is enabled.

Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
