### PR TITLE
Update message type in prefetch-on-demand controller

### DIFF
--- a/assets/src/prefetch-on-demand_controller.js
+++ b/assets/src/prefetch-on-demand_controller.js
@@ -11,9 +11,9 @@ export default class extends Controller {
         }
 
         workbox.messageSW({
-            "type": "PREFETCH",
+            "type": "CACHE_URLS",
             "payload": {
-                "urls": params.urls
+                "urlsToCache": params.urls
             }
         });
     }


### PR DESCRIPTION
The message type in the workbox.messageSW function call was updated from "PREFETCH" to "CACHE_URLS". Additionally, the payload property name was changed from "urls" to "urlsToCache" to reflect the latest method call changes.

Target branch: 1.1.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
