### PR TITLE
Add event dispatching to manifest compilation

### DIFF
--- a/src/Event/NullEventDispatcher.php
+++ b/src/Event/NullEventDispatcher.php
@@ -8,8 +8,8 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 
 final readonly class NullEventDispatcher implements EventDispatcherInterface
 {
-    public function dispatch(object $event): void
+    public function dispatch(object $event): object
     {
-        // Do nothing
+        return $event;
     }
 }

--- a/src/Event/NullEventDispatcher.php
+++ b/src/Event/NullEventDispatcher.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Event;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+final readonly class NullEventDispatcher implements EventDispatcherInterface
+{
+    public function dispatch(object $event): void
+    {
+        // Do nothing
+    }
+}

--- a/src/Event/PostManifestCompileEvent.php
+++ b/src/Event/PostManifestCompileEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Event;
+
+use SpomkyLabs\PwaBundle\Dto\Manifest;
+
+final class PostManifestCompileEvent
+{
+    public function __construct(
+        public Manifest $manifest,
+        public string $data
+    ) {
+    }
+}

--- a/src/Event/PreManifestCompileEvent.php
+++ b/src/Event/PreManifestCompileEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Event;
+
+use SpomkyLabs\PwaBundle\Dto\Manifest;
+
+class PreManifestCompileEvent
+{
+    public function __construct(
+        public Manifest $manifest,
+    ) {
+    }
+}

--- a/src/Service/ServiceWorkerCompiler.php
+++ b/src/Service/ServiceWorkerCompiler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\PwaBundle\Service;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
 use SpomkyLabs\PwaBundle\Dto\ServiceWorker;
 use SpomkyLabs\PwaBundle\ServiceWorkerRule\ServiceWorkerRuleInterface;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
@@ -27,7 +26,6 @@ final readonly class ServiceWorkerCompiler
         private iterable $serviceworkerRules,
         #[Autowire('%kernel.debug%')]
         public bool $debug,
-        null|EventDispatcherInterface $dispatcher = null
     ) {
     }
 

--- a/src/Service/ServiceWorkerCompiler.php
+++ b/src/Service/ServiceWorkerCompiler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\PwaBundle\Service;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
 use SpomkyLabs\PwaBundle\Dto\ServiceWorker;
 use SpomkyLabs\PwaBundle\ServiceWorkerRule\ServiceWorkerRuleInterface;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
@@ -26,6 +27,7 @@ final readonly class ServiceWorkerCompiler
         private iterable $serviceworkerRules,
         #[Autowire('%kernel.debug%')]
         public bool $debug,
+        null|EventDispatcherInterface $dispatcher = null
     ) {
     }
 


### PR DESCRIPTION
This update introduces event dispatching in the manifest compilation process. PreManifestCompileEvent and PostManifestCompileEvent have been added, which are dispatched before and after the compilation respectively. The modification enhances the flexibility and extensibility of the manifest compilation process by allowing custom actions just before or after compilation.

Target branch: 1.2.x

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
