### PR TITLE
add ManifestBuilder events, #173

### DIFF
--- a/src/Event/PostManifestBuildEvent.php
+++ b/src/Event/PostManifestBuildEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace SpomkyLabs\PwaBundle\Event;
+
+use SpomkyLabs\PwaBundle\Dto\Manifest;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Dispatched during the ManifestBuilder::create method, after the configuration is denormalized
+ */
+class PostManifestBuildEvent extends Event
+{
+    public function __construct(private Manifest $manifest)
+    {
+    }
+
+    public function setManifest(Manifest $manifest): void
+    {
+        $this->manifest = $manifest;
+    }
+
+    public function getManifest(): Manifest
+    {
+        return $this->manifest;
+    }
+}
+

--- a/src/Event/PreManifestBuildEvent.php
+++ b/src/Event/PreManifestBuildEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace SpomkyLabs\PwaBundle\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Dispatched during the ManifestBuilder::create method, before the configuration is denormalized
+ */
+class PreManifestBuildEvent extends Event
+{
+    public function __construct(private array $config)
+    {
+    }
+
+    public function setConfig(array $config): void
+    {
+        $this->config = $config;
+    }
+
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+}

--- a/src/Service/ManifestBuilder.php
+++ b/src/Service/ManifestBuilder.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace SpomkyLabs\PwaBundle\Service;
 
 use SpomkyLabs\PwaBundle\Dto\Manifest;
+use SpomkyLabs\PwaBundle\Event\PostManifestBuildEvent;
+use SpomkyLabs\PwaBundle\Event\PreManifestBuildEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use function assert;
 
@@ -17,6 +20,7 @@ final class ManifestBuilder
      */
     public function __construct(
         private readonly DenormalizerInterface $denormalizer,
+        private readonly null|EventDispatcherInterface $dispatcher,
         private readonly array $config,
     ) {
     }
@@ -24,8 +28,10 @@ final class ManifestBuilder
     public function create(): Manifest
     {
         if ($this->manifest === null) {
+            $this->dispatcher->dispatch(new PreManifestBuildEvent($this->config));
             $result = $this->denormalizer->denormalize($this->config, Manifest::class);
             assert($result instanceof Manifest);
+            $this->dispatcher->dispatch(new PostManifestBuildEvent($this->manifest));
             $this->manifest = $result;
         }
 


### PR DESCRIPTION
Target branch: 1.2.x
Resolves issue #173 

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ X] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Dispatches events during the manifest build step.  For example, if there's no description in pwa.yaml, get it from composer.json

```php
final class PwaConfigListener
{
    #[AsEventListener(event: PreManifestBuildEvent::class)]
    public function onPreBuildManifest($event): void
    {
        $config = $event->getConfig();
        if (empty($config['description'])) {
            $composerData = json_decode(file_get_contents(__DIR__.'/../../composer.json'), true);
            $config['description'] = $composerData['description']??'missing description!';
            $event->setConfig($config);
        }
    }
```