### PR TITLE
Add favicon generation functionalities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "ekino/phpstan-banned-code": "^1.0",
         "ergebnis/phpunit-slow-test-detector": "^2.14",
         "infection/infection": "^0.28",
+        "matthiasnoback/symfony-config-test": "^5.1",
         "php-parallel-lint/php-parallel-lint": "^1.4",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpdoc-parser": "^1.28",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -181,6 +181,11 @@ parameters:
 			path: src/Dto/BackgroundSync.php
 
 		-
+			message: "#^Class SpomkyLabs\\\\PwaBundle\\\\Dto\\\\Favicons has an uninitialized property \\$src\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: src/Dto/Favicons.php
+
+		-
 			message: "#^Class SpomkyLabs\\\\PwaBundle\\\\Dto\\\\File has an uninitialized property \\$accept\\. Give it default value or assign it in the constructor\\.$#"
 			count: 1
 			path: src/Dto/File.php
@@ -441,13 +446,23 @@ parameters:
 			path: src/ImageProcessor/GDImageProcessor.php
 
 		-
+			message: "#^Parameter \\#1 \\$dst_image of function imagecopyresampled expects GdImage, GdImage\\|false given\\.$#"
+			count: 1
+			path: src/ImageProcessor/GDImageProcessor.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of function imagealphablending expects GdImage, GdImage\\|false given\\.$#"
+			count: 1
+			path: src/ImageProcessor/GDImageProcessor.php
+
+		-
 			message: "#^Parameter \\#1 \\$image of function imagepng expects GdImage, GdImage\\|false given\\.$#"
 			count: 1
 			path: src/ImageProcessor/GDImageProcessor.php
 
 		-
 			message: "#^Parameter \\#1 \\$image of function imagesavealpha expects GdImage, GdImage\\|false given\\.$#"
-			count: 1
+			count: 2
 			path: src/ImageProcessor/GDImageProcessor.php
 
 		-
@@ -484,6 +499,11 @@ parameters:
 			message: "#^Method SpomkyLabs\\\\PwaBundle\\\\Normalizer\\\\ServiceWorkerNormalizer\\:\\:normalize\\(\\) should return array\\{scope\\?\\: string, src\\: string, use_cache\\?\\: bool\\} but returns array\\<mixed\\>\\.$#"
 			count: 1
 			path: src/Normalizer/ServiceWorkerNormalizer.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeDefinition\\:\\:children\\(\\)\\.$#"
+			count: 1
+			path: src/Resources/config/definition/favicons.php
 
 		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeDefinition\\:\\:children\\(\\)\\.$#"
@@ -624,13 +644,3 @@ parameters:
 			message: "#^Method SpomkyLabs\\\\PwaBundle\\\\SpomkyLabsPwaBundle\\:\\:loadExtension\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/SpomkyLabsPwaBundle.php
-
-		-
-			message: "#^Property SpomkyLabs\\\\PwaBundle\\\\Subscriber\\\\ManifestCompileEventListener\\:\\:\\$jsonOptions type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Subscriber/ManifestCompileEventListener.php
-
-		-
-			message: "#^Property SpomkyLabs\\\\PwaBundle\\\\Subscriber\\\\PwaDevServerSubscriber\\:\\:\\$jsonOptions type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Subscriber/PwaDevServerSubscriber.php

--- a/src/Dto/Favicons.php
+++ b/src/Dto/Favicons.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Dto;
+
+use Symfony\Component\Serializer\Attribute\SerializedName;
+
+final class Favicons
+{
+    public bool $enabled = false;
+
+    public Asset $src;
+
+    #[SerializedName('background_color')]
+    public null|string $backgroundColor = null;
+
+    #[SerializedName('safari_pinned_tab_color')]
+    public null|string $safariPinnedTabColor = null;
+
+    #[SerializedName('tile_color')]
+    public null|string $tileColor = null;
+
+    /**
+     * @var int<1, 50>|null
+     */
+    #[SerializedName('border_radius')]
+    public null|int $borderRadius = null;
+
+    /**
+     * @var int<1, 100>|null
+     */
+    #[SerializedName('image_scale')]
+    public null|int $imageScale = null;
+
+    #[SerializedName('only_high_resolution')]
+    public null|bool $onlyHighResolution = null;
+
+    #[SerializedName('only_tile_silhouette')]
+    public null|bool $onlyTileSilhouette = null;
+}

--- a/src/ImageProcessor/GDImageProcessor.php
+++ b/src/ImageProcessor/GDImageProcessor.php
@@ -17,7 +17,15 @@ final readonly class GDImageProcessor implements ImageProcessorInterface
         assert($image !== false);
         imagealphablending($image, true);
         if ($width !== null && $height !== null) {
-            $image = imagescale($image, $width, $height);
+            if ($width === $height) {
+                $image = imagescale($image, $width, $height);
+            } else {
+                $newImage = imagecreatetruecolor($width, $height);
+                imagealphablending($newImage, false);
+                imagesavealpha($newImage, true);
+                imagecopyresampled($newImage, $image, 0, 0, 0, 0, $width, $height, imagesx($image), imagesy($image));
+                $image = $newImage;
+            }
         }
         ob_start();
         imagesavealpha($image, true);

--- a/src/ImageProcessor/ImagickImageProcessor.php
+++ b/src/ImageProcessor/ImagickImageProcessor.php
@@ -9,12 +9,6 @@ use ImagickPixel;
 
 final readonly class ImagickImageProcessor implements ImageProcessorInterface
 {
-    public function __construct(
-        private int $filters = Imagick::FILTER_LANCZOS2,
-        private float $blur = 1,
-    ) {
-    }
-
     public function process(string $image, ?int $width, ?int $height, ?string $format): string
     {
         if ($width === null && $height === null) {
@@ -23,7 +17,17 @@ final readonly class ImagickImageProcessor implements ImageProcessorInterface
         $imagick = new Imagick();
         $imagick->readImageBlob($image);
         if ($width !== null && $height !== null) {
-            $imagick->resizeImage($width, $height, $this->filters, $this->blur, true);
+            if ($width === $height) {
+                $imagick->scaleImage($width, $height);
+            } else {
+                $imagick->scaleImage(min($width, $height), min($width, $height));
+                $imagick->extentImage(
+                    $width,
+                    $height,
+                    -($width - min($width, $height)) / 2,
+                    -($height - min($width, $height)) / 2
+                );
+            }
         }
         $imagick->setImageBackgroundColor(new ImagickPixel('transparent'));
         if ($format !== null) {

--- a/src/Resources/config/definition/favicons.php
+++ b/src/Resources/config/definition/favicons.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+
+return static function (DefinitionConfigurator $definition): void {
+    $definition->rootNode()
+        ->beforeNormalization()
+            ->ifTrue(
+                static fn (null|array $v): bool => $v !== null && isset($v['manifest']) && $v['manifest']['enabled'] === true && isset($v['favicons']) && $v['favicons']['enabled'] === true && isset($v['manifest']['theme_color'])
+            )
+            ->then(static function (array $v): array {
+                $v['favicons']['background_color'] = $v['manifest']['theme_color'];
+                return $v;
+            })
+        ->end()
+        ->children()
+            ->arrayNode('favicons')
+                ->canBeEnabled()
+                ->children()
+                    ->scalarNode('src')
+                        ->isRequired()
+                        ->info('The source of the favicon. Shall be a SVG or large PNG.')
+                    ->end()
+                    ->scalarNode('background_color')
+                        ->defaultNull()
+                        ->info(
+                            'The background color of the application. If this value is not defined and that of the Manifest section is, the value of the latter will be used.'
+                        )
+                        ->example(['red', '#f5ef06'])
+                    ->end()
+                    ->scalarNode('safari_pinned_tab_color')
+                        ->defaultNull()
+                        ->info('The color of the Safari pinned tab.')
+                        ->example(['red', '#f5ef06'])
+                    ->end()
+                    ->scalarNode('tile_color')
+                        ->defaultNull()
+                        ->info('The color of the tile for Windows 8+.')
+                        ->example(['red', '#f5ef06'])
+                    ->end()
+                    ->integerNode('border_radius')
+                        ->defaultNull()
+                        ->min(1)
+                        ->max(50)
+                        ->info('The border radius of the icon.')
+                    ->end()
+                    ->integerNode('image_scale')
+                        ->defaultNull()
+                        ->min(1)
+                        ->max(100)
+                        ->info('The scale of the icon.')
+                    ->end()
+                    ->booleanNode('generate_precomposed')
+                        ->defaultFalse()
+                        ->info('Generate precomposed icons. Useful for old iOS devices.')
+                    ->end()
+                    ->booleanNode('only_high_resolution')
+                        ->defaultTrue()
+                        ->info('Only high resolution icons.')
+                    ->end()
+                    ->booleanNode('only_tile_silhouette')
+                        ->defaultTrue()
+                        ->info('Only tile silhouette for Windows 8+.')
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+    ->end();
+};

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -10,12 +10,15 @@ use SpomkyLabs\PwaBundle\Command\CreateIconsCommand;
 use SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand;
 use SpomkyLabs\PwaBundle\Command\ListCacheStrategiesCommand;
 use SpomkyLabs\PwaBundle\DataCollector\PwaCollector;
+use SpomkyLabs\PwaBundle\Dto\Favicons;
 use SpomkyLabs\PwaBundle\Dto\Manifest;
 use SpomkyLabs\PwaBundle\Dto\ServiceWorker;
 use SpomkyLabs\PwaBundle\EventSubscriber\ScreenshotSubscriber;
 use SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor;
 use SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor;
 use SpomkyLabs\PwaBundle\MatchCallbackHandler\MatchCallbackHandlerInterface;
+use SpomkyLabs\PwaBundle\Service\FaviconsBuilder;
+use SpomkyLabs\PwaBundle\Service\FaviconsCompiler;
 use SpomkyLabs\PwaBundle\Service\FileCompilerInterface;
 use SpomkyLabs\PwaBundle\Service\ManifestBuilder;
 use SpomkyLabs\PwaBundle\Service\ManifestCompiler;
@@ -55,6 +58,17 @@ return static function (ContainerConfigurator $configurator): void {
         ->factory([service(ManifestBuilder::class), 'create'])
     ;
     $container->set(ManifestCompiler::class);
+
+    /*** Favicons ***/
+    $container->set(FaviconsBuilder::class)
+        ->args([
+            '$config' => param('spomky_labs_pwa.favicons.config'),
+        ])
+    ;
+    $container->set(Favicons::class)
+        ->factory([service(FaviconsBuilder::class), 'create'])
+    ;
+    $container->set(FaviconsCompiler::class);
 
     /*** Service Worker ***/
     $container->set(ServiceWorkerBuilder::class)

--- a/src/Service/Data.php
+++ b/src/Service/Data.php
@@ -10,17 +10,17 @@ namespace SpomkyLabs\PwaBundle\Service;
 final readonly class Data
 {
     /**
-     * @param string[] $headers
+     * @param array<string, string|bool> $headers
      */
     public function __construct(
         public string $url,
         public string $data,
         public array $headers
-    ){
+    ) {
     }
 
     /**
-     * @param array<string, string> $headers
+     * @param array<string, string|bool> $headers
      */
     public static function create(string $url, string $data, array $headers = []): self
     {

--- a/src/Service/FaviconsBuilder.php
+++ b/src/Service/FaviconsBuilder.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Service;
+
+use SpomkyLabs\PwaBundle\Dto\Favicons;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use function assert;
+
+final class FaviconsBuilder
+{
+    private null|Favicons $favicons = null;
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(
+        private readonly DenormalizerInterface $denormalizer,
+        private readonly array $config,
+    ) {
+    }
+
+    public function create(): Favicons
+    {
+        if ($this->favicons === null) {
+            $result = $this->denormalizer->denormalize($this->config, Favicons::class);
+            assert($result instanceof Favicons);
+            $this->favicons = $result;
+        }
+
+        return $this->favicons;
+    }
+}

--- a/src/Service/FaviconsCompiler.php
+++ b/src/Service/FaviconsCompiler.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Service;
+
+use SpomkyLabs\PwaBundle\Dto\Favicons;
+use SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface;
+use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\AssetMapper\MappedAsset;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use function assert;
+use const PHP_EOL;
+
+final class FaviconsCompiler implements FileCompilerInterface
+{
+    /**
+     * @var null|array<string, Data>
+     */
+    private null|array $files = null;
+
+    public function __construct(
+        private readonly null|ImageProcessorInterface $imageProcessor,
+        private readonly Favicons $favicons,
+        private readonly AssetMapperInterface $assetMapper,
+        #[Autowire('%kernel.debug%')]
+        public readonly bool $debug,
+    ) {
+    }
+
+    /**
+     * @return array<string, Data>
+     */
+    public function getFiles(): array
+    {
+        if ($this->files !== null) {
+            return $this->files;
+        }
+        if ($this->imageProcessor === null || $this->favicons->enabled === false) {
+            return [];
+        }
+        $asset = $this->assetMapper->getAsset($this->favicons->src->src);
+        assert($asset !== null, 'The asset does not exist.');
+        $this->files = [
+            '/favicon.ico' => $this->processIcon($asset, '/favicon.ico', 16, 16, 'ico', 'image/x-icon'),
+        ];
+        $sizes = [16, 32, 36, 48, 57, 60, 70, 72, 76, 96, 114, 120, 144, 150, 152, 180, 192, 194, 256, 310, 384, 512];
+        foreach ($sizes as $size) {
+            $this->files[sprintf('/favicons/icon-%dx%d.png', $size, $size)] = $this->processIcon(
+                $asset,
+                sprintf('/favicons/icon-%dx%d.{hash}.png', $size, $size),
+                $size,
+                $size,
+                'png',
+                'image/png'
+            );
+        }
+        if ($this->favicons->tileColor !== null) {
+            $this->files['/favicons/icon-310x150.png'] = $this->processIcon(
+                $asset,
+                '/favicons/icon-310x150.{hash}.png',
+                310,
+                150,
+                'png',
+                'image/png'
+            );
+            $this->files['/favicons/browserconfig.xml'] = $this->processBrowserConfig();
+        }
+
+        return $this->files;
+    }
+
+    private function processIcon(
+        MappedAsset $asset,
+        string $publicUrl,
+        int $width,
+        int $height,
+        string $format,
+        string $mimeType
+    ): Data {
+        $content = file_get_contents($asset->sourcePath);
+        assert($content !== false);
+        if ($this->debug === true) {
+            $hash = hash('xxh128', $content);
+            return Data::create(
+                str_replace(['{hash}', '.png'], [$hash, '.svg'], $publicUrl),
+                $content,
+                [
+                    'Cache-Control' => 'public, max-age=604800, immutable',
+                    'Content-Type' => 'image/svg+xml',
+                    'X-Favicons-Dev' => true,
+                    'Etag' => $hash,
+                ]
+            );
+        }
+        assert($this->imageProcessor !== null);
+        $data = $this->imageProcessor->process($content, $width, $height, $format);
+        return Data::create(
+            str_replace('{hash}', hash('xxh128', $data), $publicUrl),
+            $data,
+            [
+                'Cache-Control' => 'public, max-age=604800, immutable',
+                'Content-Type' => $mimeType,
+                'X-Favicons-Dev' => true,
+                'Etag' => hash('xxh128', $data),
+            ]
+        );
+    }
+
+    private function processBrowserConfig(): Data
+    {
+        $icon310x150 = $this->files['/favicons/icon-310x150.png'] ?? null;
+        $icon70x70 = $this->files['/favicons/icon-70x70.png'] ?? null;
+        $icon150x150 = $this->files['/favicons/icon-150x150.png'] ?? null;
+        $icon310x310 = $this->files['/favicons/icon-310x310.png'] ?? null;
+        assert($icon310x150 !== null);
+        assert($icon70x70 !== null);
+        assert($icon150x150 !== null);
+        assert($icon310x310 !== null);
+        if ($this->favicons->tileColor === null) {
+            $tileColor = '';
+        } else {
+            $tileColor = sprintf(PHP_EOL . '            <TileColor>%s</TileColor>', $this->favicons->tileColor);
+        }
+
+        $content = <<<XML
+<?xml version="1.0" encoding="utf-8"?>
+<browserconfig>
+    <msapplication>
+        <tile>
+            <square70x70logo src="{$icon70x70->url}"/>
+            <square150x150logo src="{$icon150x150->url}"/>
+            <square310x310logo src="{$icon310x310->url}"/>
+            <wide310x150logo src="{$icon310x150->url}"/>{$tileColor}
+        </tile>
+    </msapplication>
+</browserconfig>
+XML;
+        $hash = hash('xxh128', $content);
+        return Data::create(
+            sprintf('/favicons/browserconfig.%s.xml', $hash),
+            $content,
+            [
+                'Cache-Control' => 'public, max-age=604800, immutable',
+                'Content-Type' => 'application/xml',
+                'X-Favicons-Dev' => true,
+                'Etag' => $hash,
+            ]
+        );
+    }
+}

--- a/src/Service/FileCompilerInterface.php
+++ b/src/Service/FileCompilerInterface.php
@@ -7,9 +7,7 @@ namespace SpomkyLabs\PwaBundle\Service;
 interface FileCompilerInterface
 {
     /**
-     * @return array<string>
+     * @return iterable<string, Data>
      */
-    public function supportedPublicUrls(): array;
-
-    public function get(string $publicUrl): null|Data;
+    public function getFiles(): iterable;
 }

--- a/src/Service/ManifestCompiler.php
+++ b/src/Service/ManifestCompiler.php
@@ -61,40 +61,21 @@ final class ManifestCompiler implements FileCompilerInterface
     }
 
     /**
-     * @return array<string>
+     * @return iterable<string, Data>
      */
-    public function supportedPublicUrls(): array
+    public function getFiles(): iterable
     {
         if ($this->manifest->enabled === false) {
             return [];
         }
 
         if ($this->locales === []) {
-            return [$this->manifestPublicUrl];
-        }
-
-        return array_map(
-            fn (string $locale) => str_replace('{locale}', $locale, $this->manifestPublicUrl),
-            $this->locales
-        );
-    }
-
-    public function get(string $publicUrl): null|Data
-    {
-        if ($this->manifest->enabled === false) {
-            return null;
-        }
-        if ($this->locales === []) {
-            return $this->compileManifest(null);
+            yield $this->manifestPublicUrl => $this->compileManifest(null);
         }
 
         foreach ($this->locales as $locale) {
-            if ($publicUrl === str_replace('{locale}', $locale, $this->manifestPublicUrl)) {
-                return $this->compileManifest($locale);
-            }
+            yield str_replace('{locale}', $locale, $this->manifestPublicUrl) => $this->compileManifest($locale);
         }
-
-        return null;
     }
 
     private function compileManifest(null|string $locale): Data

--- a/src/Subscriber/FileCompileEventListener.php
+++ b/src/Subscriber/FileCompileEventListener.php
@@ -28,11 +28,7 @@ final readonly class FileCompileEventListener
     public function __invoke(PreAssetsCompileEvent $event): void
     {
         foreach ($this->fileCompilers as $fileCompiler) {
-            foreach ($fileCompiler->supportedPublicUrls() as $publicUrl) {
-                $data = $fileCompiler->get($publicUrl);
-                if ($data === null) {
-                    continue;
-                }
+            foreach ($fileCompiler->getFiles() as $data) {
                 $this->assetsFilesystem->write($data->url, $data->data);
             }
         }

--- a/src/Subscriber/PwaDevServerSubscriber.php
+++ b/src/Subscriber/PwaDevServerSubscriber.php
@@ -13,7 +13,6 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
-use function in_array;
 
 final readonly class PwaDevServerSubscriber implements EventSubscriberInterface
 {
@@ -36,10 +35,13 @@ final readonly class PwaDevServerSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
         $pathInfo = $request->getPathInfo();
         foreach ($this->fileCompilers as $fileCompiler) {
-            if (in_array($pathInfo, $fileCompiler->supportedPublicUrls(), true)) {
-                $data = $fileCompiler->get($pathInfo);
-                assert($data !== null);
+            $files = iterator_to_array($fileCompiler->getFiles());
+            foreach ($files as $data) {
+                if ($data->url !== $pathInfo) {
+                    continue;
+                }
                 $this->serveFile($event, $data);
+                return;
             }
         }
     }

--- a/tests/Functional/ConfigurationTest.php
+++ b/tests/Functional/ConfigurationTest.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Functional;
+
+use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor;
+use SpomkyLabs\PwaBundle\SpomkyLabsPwaBundle;
+use SpomkyLabs\PwaBundle\Tests\DummyImageProcessor;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Config\Definition\Configuration;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+final class ConfigurationTest extends KernelTestCase
+{
+    use ConfigurationTestCaseTrait;
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    #[Test]
+    #[DataProvider('dataConfigurationIsValid')]
+    public function configurationIsValid(array $configuration): void
+    {
+        $this->assertConfigurationIsValid($configuration);
+    }
+
+    /**
+     * @return array<array-key, mixed>[]
+     */
+    public static function dataConfigurationIsValid(): iterable
+    {
+        yield 'No configuration values' => [[]];
+        yield 'Empty configuration' => [[
+            'pwa' => null,
+        ]];
+        yield 'Image processor is defined' => [[
+            'pwa' => [
+                'image_processor' => ImagickImageProcessor::class,
+                'web_client' => 'id_web_client',
+                'user_agent' => 'user-agent/1.0',
+            ],
+        ]];
+        yield 'Favicons only' => [[
+            'pwa' => [
+                'favicons' => [
+                    'enabled' => true,
+                    'src' => 'pwa/1920x1920.svg',
+                ],
+            ],
+        ]];
+        yield 'Manifest only' => [[
+            'pwa' => [
+                'manifest' => [
+                    'enabled' => true,
+                ],
+            ],
+        ]];
+        yield 'Service Worker only' => [[
+            'pwa' => [
+                'serviceworker' => [
+                    'enabled' => true,
+                    'src' => __DIR__ . '/sw.js',
+                ],
+            ],
+        ]];
+        yield 'Complete configuration' => [[
+            'pwa' => [
+                'image_processor' => DummyImageProcessor::class,
+                'favicons' => [
+                    'enabled' => true,
+                    'src' => 'pwa/1920x1920.svg',
+                ],
+                'manifest' => [
+                    'enabled' => true,
+                    'background_color' => 'red',
+                    'categories' => ['pwa.categories.0', 'pwa.categories.1', 'pwa.categories.2'],
+                    'description' => 'pwa.description',
+                    'display' => 'standalone',
+                    'display_override' => ['fullscreen', 'minimal-ui'],
+                    'file_handlers' => [
+                        [
+                            'action' => [
+                                'path' => 'audio_file_handler',
+                                'params' => [
+                                    'param1' => 'audio',
+                                ],
+                            ],
+                            'accept' => [
+                                'audio/wav' => ['.wav'],
+                                'audio/x-wav' => ['.wav'],
+                                'audio/mpeg' => ['.mp3'],
+                                'audio/mp4' => ['.mp4'],
+                                'audio/aac' => ['.adts'],
+                                'audio/ogg' => ['.ogg'],
+                                'application/ogg' => ['.ogg'],
+                                'audio/webm' => ['.webm'],
+                                'audio/flac' => ['.flac'],
+                                'audio/mid' => ['.rmi', '.mid'],
+                            ],
+                        ],
+                    ],
+                    'icons' => [
+                        [
+                            'src' => 'pwa/1920x1920.svg',
+                            'sizes' => [48, 72, 96, 128, 256],
+                            'type' => 'webp',
+                        ],
+                        [
+                            'src' => 'pwa/1920x1920.svg',
+                            'sizes' => [48, 72, 96, 128, 256],
+                            'type' => 'png',
+                            'purpose' => 'maskable',
+                        ],
+                        [
+                            'src' => 'pwa/1920x1920.svg',
+                            'sizes' => [0],
+                        ],
+                    ],
+                    'id' => '/?homescreen=1',
+                    'launch_handler' => [
+                        'client_mode' => ['focus-existing', 'auto'],
+                    ],
+                    'orientation' => 'portrait-primary',
+                    'prefer_related_applications' => true,
+                    'dir' => 'rtl',
+                    'lang' => 'ar',
+                    'name' => 'pwa.name',
+                    'short_name' => 'pwa.short_name',
+                    'protocol_handlers' => [
+                        [
+                            'protocol' => 'web+jngl',
+                            'url' => '/lookup?type=%s',
+                        ],
+                        [
+                            'protocol' => 'web+jnglstore',
+                            'url' => '/shop?for=%s',
+                        ],
+                    ],
+                    'related_applications' => [
+                        [
+                            'platform' => 'play',
+                            'url' => 'https://play.google.com/store/apps/details?id=com.example.app1',
+                            'id' => 'com.example.app1',
+                        ],
+                        [
+                            'platform' => 'itunes',
+                            'url' => 'https://itunes.apple.com/app/example-app1/id123456789',
+                        ],
+                        [
+                            'platform' => 'windows',
+                            'url' => 'https://apps.microsoft.com/store/detail/example-app1/id123456789',
+                        ],
+                    ],
+                    'scope' => '/',
+                    'start_url' => 'pwa.start_url',
+                    'theme_color' => 'red',
+                    'screenshots' => [
+                        [
+                            'src' => 'pwa/screenshots/360x800.svg',
+                            'label' => 'pwa.screenshots.0',
+                        ],
+                    ],
+                    'share_target' => [
+                        'action' => [
+                            'path' => 'shared_content_receiver',
+                            'params' => [
+                                'param1' => 'value1',
+                                'param2' => 'value2',
+                            ],
+                        ],
+                        'method' => 'GET',
+                        'params' => [
+                            'title' => 'name',
+                            'text' => 'description',
+                            'url' => 'link',
+                        ],
+                    ],
+                    'shortcuts' => [
+                        [
+                            'name' => "Today's agenda",
+                            'url' => [
+                                'path' => 'agenda',
+                                'params' => [
+                                    'date' => 'today',
+                                ],
+                            ],
+                            'description' => 'List of events planned for today',
+                        ],
+                        [
+                            'name' => 'New event',
+                            'url' => '/create/event',
+                        ],
+                        [
+                            'name' => 'New reminder',
+                            'url' => '/create/reminder',
+                            'icons' => [
+                                'pwa/1920x1920.svg',
+                                [
+                                    'src' => 'pwa/1920x1920.svg',
+                                    'purpose' => 'maskable',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'edge_side_panel' => [
+                        'preferred_width' => 480,
+                    ],
+                    'iarc_rating_id' => '123456',
+                    'scope_extensions' => [
+                        [
+                            'origin' => '*.foo.com',
+                        ],
+                        [
+                            'origin' => 'https://*.bar.com',
+                        ],
+                        [
+                            'origin' => 'https://*.baz.com',
+                        ],
+                    ],
+                    'widgets' => [
+                        [
+                            'name' => 'PWAmp mini player',
+                            'description' => 'widget to control the PWAmp music player',
+                            'tag' => 'pwamp',
+                            'template' => 'pwamp-template',
+                            'ms_ac_template' => 'app_widget_template',
+                            'data' => 'app_widget_data',
+                            'type' => 'application/json',
+                            'screenshots' => [
+                                [
+                                    'src' => 'pwa/1920x1920.svg',
+                                    'label' => 'The PWAmp mini-player widget',
+                                ],
+                            ],
+                            'icons' => [
+                                [
+                                    'src' => 'pwa/1920x1920.svg',
+                                    'sizes' => [16, 48],
+                                    'type' => 'webp',
+                                ],
+                            ],
+                            'auth' => false,
+                            'update' => 86400,
+                        ],
+                    ],
+                    'handle_links' => 'auto',
+                ],
+                'serviceworker' => [
+                    'enabled' => true,
+                    'src' => __DIR__ . '/sw.js',
+                    'scope' => '/',
+                    'use_cache' => true,
+                    'workbox' => [
+                        'resource_caches' => [
+                            [
+                                'match_callback' => 'regex:.*',
+                                'strategy' => 'StaleWhileRevalidate',
+                                'cache_name' => 'page-cache',
+                                'broadcast' => true,
+                                'preload_urls' => ['privacy_policy', 'terms_of_service', '@static-pages', '@widgets'],
+                            ],
+                        ],
+                        'offline_fallback' => [
+                            'page' => '/offline.html',
+                        ],
+                    ],
+                ],
+            ],
+        ]];
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    #[Test]
+    #[DataProvider('dataConfigurationIsInvalid')]
+    public function configurationIsInvalid(array $configuration, string $message): void
+    {
+        $this->assertConfigurationIsInvalid($configuration, $message);
+    }
+
+    /**
+     * @return array<array-key, mixed>[]
+     */
+    public static function dataConfigurationIsInvalid(): iterable
+    {
+        yield 'No configuration values' => [
+            [
+                'pwa' => [
+                    'favicons' => 10,
+                ],
+            ],
+            'Invalid type for path "pwa.favicons". Expected "array", but got "int"',
+        ];
+        yield 'No favicon source' => [
+            [
+                'pwa' => [
+                    'favicons' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ],
+            'The child config "src" under "pwa.favicons" must be configured: The source of the favicon. Shall be a SVG or large PNG.',
+        ];
+        yield 'No service worker source' => [
+            [
+                'pwa' => [
+                    'serviceworker' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ],
+            'The child config "src" under "pwa.serviceworker" must be configured: The path to the service worker source file. Can be served by Asset Mapper.',
+        ];
+    }
+
+    protected function getConfiguration(): ConfigurationInterface
+    {
+        return new Configuration(new SpomkyLabsPwaBundle(), null, 'pwa');
+    }
+}

--- a/tests/config.php
+++ b/tests/config.php
@@ -55,6 +55,10 @@ return static function (ContainerConfigurator $container) {
     ]);
     $container->extension('pwa', [
         'image_processor' => DummyImageProcessor::class,
+        'favicons' => [
+            'enabled' => true,
+            'src' => 'pwa/1920x1920.svg',
+        ],
         'manifest' => [
             'enabled' => true,
             'background_color' => 'red',


### PR DESCRIPTION
Introduce favicon generation capabilities using the GDImage library and workbox integration for service worker builds. This includes browser config for Windows 8+ tile architecture, supporting different image sizes and output formats. New validations in the configuration test ensure that these additions function as expected. Modifications in the service worker compiler class aim at better usage of interfaces and performance improvements.

Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
