### PR TITLE
Refactor prefetch method to use async/await

### DIFF
--- a/assets/src/prefetch-on-demand_controller.js
+++ b/assets/src/prefetch-on-demand_controller.js
@@ -4,17 +4,25 @@ import { Controller } from '@hotwired/stimulus';
 
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {
-    prefetch = ({params}) => {
+    prefetch = async ({params}) => {
         const workbox = window.workbox;
         if (!workbox || !params.urls) {
             return;
         }
 
-        workbox.messageSW({
+        const result = await workbox.messageSW({
             "type": "CACHE_URLS",
             "payload": {
                 "urlsToCache": params.urls
             }
         });
+        this.dispatchEvent(
+            result === true ?'prefetched': 'error',
+            {params}
+        );
+    }
+
+    dispatchEvent = (name, payload) => {
+        this.dispatch(name, { detail: payload });
     }
 }


### PR DESCRIPTION
This commit refactors the prefetch method in prefetch-on-demand_controller to use async/await for better error handling. The response from the workbox.messageSW method call is now awaited, and an event is dispatched based on the result, informing whether prefetching was successful or not.

Target branch: 1.2.x
Resolves issue #192 

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
