### PR TITLE
Refactor Data class and update method calls

### DIFF
--- a/src/DataCollector/PwaCollector.php
+++ b/src/DataCollector/PwaCollector.php
@@ -82,7 +82,14 @@ final class PwaCollector extends DataCollector
         $this->data['favicons'] = [
             'enabled' => $this->favicons->enabled,
             'data' => $this->favicons,
-            'files' => $faviconsFiles,
+            'files' => array_map(
+                static fn (\SpomkyLabs\PwaBundle\Service\Data $data): array => [
+                    'url' => $data->url,
+                    'headers' => $data->headers,
+                    'html' => $data->html,
+                ],
+                $faviconsFiles
+            ),
         ];
     }
 

--- a/src/Service/Data.php
+++ b/src/Service/Data.php
@@ -4,27 +4,47 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\PwaBundle\Service;
 
+use Closure;
+
 /**
  * @internal
  */
-final readonly class Data
+final class Data
 {
     /**
      * @param array<string, string|bool> $headers
      */
     public function __construct(
-        public string $url,
-        public string $data,
-        public array $headers,
-        public null|string $html = null,
+        public readonly string $url,
+        private string|Closure $data,
+        public readonly array $headers,
+        public readonly null|string $html = null,
     ) {
     }
 
     /**
      * @param array<string, string|bool> $headers
      */
-    public static function create(string $url, string $data, array $headers = [], null|string $html = null): self
-    {
+    public static function create(
+        string $url,
+        string|Closure $data,
+        array $headers = [],
+        null|string $html = null
+    ): self {
         return new self($url, $data, $headers, $html);
+    }
+
+    public function getData(): string
+    {
+        if ($this->data instanceof Closure) {
+            $this->data = ($this->data)();
+        }
+
+        return $this->data;
+    }
+
+    public function getRawData(): string|Closure
+    {
+        return $this->data;
     }
 }

--- a/src/Subscriber/FileCompileEventListener.php
+++ b/src/Subscriber/FileCompileEventListener.php
@@ -29,7 +29,7 @@ final readonly class FileCompileEventListener
     {
         foreach ($this->fileCompilers as $fileCompiler) {
             foreach ($fileCompiler->getFiles() as $data) {
-                $this->assetsFilesystem->write($data->url, $data->data);
+                $this->assetsFilesystem->write($data->url, $data->getData());
             }
         }
     }

--- a/src/Subscriber/PwaDevServerSubscriber.php
+++ b/src/Subscriber/PwaDevServerSubscriber.php
@@ -68,7 +68,7 @@ final readonly class PwaDevServerSubscriber implements EventSubscriberInterface
     private function serveFile(RequestEvent $event, Data $data): void
     {
         $this->profiler?->disable();
-        $response = new Response($data->data, Response::HTTP_OK, $data->headers);
+        $response = new Response($data->getData(), Response::HTTP_OK, $data->headers);
         $event->setResponse($response);
         $event->stopPropagation();
     }

--- a/tests/Functional/DevServerTest.php
+++ b/tests/Functional/DevServerTest.php
@@ -6,6 +6,7 @@ namespace SpomkyLabs\PwaBundle\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @internal
@@ -19,7 +20,7 @@ final class DevServerTest extends WebTestCase
         $client = static::createClient();
 
         // When
-        $client->request('GET', '/site.webmanifest');
+        $client->request(Request::METHOD_GET, '/site.webmanifest');
 
         // Then
         static::assertResponseIsSuccessful();
@@ -33,7 +34,7 @@ final class DevServerTest extends WebTestCase
         $client = static::createClient();
 
         // When
-        $client->request('GET', '/sw.js');
+        $client->request(Request::METHOD_GET, '/sw.js');
 
         // Then
         static::assertResponseIsSuccessful();


### PR DESCRIPTION
The Data class has been refactored to accept a Closure for the data field and expose getData and getRawData methods. Consequently, adjustments were made to the FaviconsCompiler, FileCompileEventListener, and PwaDevServerSubscriber classes to accommodate these changes.

Target branch: 1.2.x
Resolves issue #200

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
