### PR TITLE
Update screenshot format examples in config

### DIFF
--- a/src/Resources/config/definition/utils/screenshots.php
+++ b/src/Resources/config/definition/utils/screenshots.php
@@ -49,7 +49,7 @@ function getScreenshotsNode(string $info): ArrayNodeDefinition
         ->end()
         ->scalarNode('format')
         ->info('The format of the screenshot. Will convert the file if set.')
-        ->example(['image/jpg', 'image/png', 'image/webp'])
+        ->example(['jpg', 'png', 'webp'])
         ->end()
         ->scalarNode('reference')
             ->defaultNull()


### PR DESCRIPTION
In the screenshot configuration of the utility settings, the example values for the screenshot format are updated to simple file extensions 'jpg', 'png', and 'webp', instead of the MIME types.

Target branch: 1.1.x
Resolves issue #171

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
