### PR TITLE
Add display of preloaded URLs in ServiceWorker tab

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,11 @@ parameters:
 			path: src/CachingStrategy/AssetCache.php
 
 		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/CachingStrategy/BackgroundSync.php
+
+		-
 			message: "#^Only iterables can be unpacked, mixed given in argument \\#1\\.$#"
 			count: 1
 			path: src/CachingStrategy/FontCache.php
@@ -34,6 +39,16 @@ parameters:
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 2
 			path: src/CachingStrategy/FontCache.php
+
+		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/CachingStrategy/PreloadUrlsGeneratorManager.php
+
+		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/CachingStrategy/ResourceCaches.php
 
 		-
 			message: "#^Only iterables can be unpacked, mixed given in argument \\#1\\.$#"
@@ -119,6 +134,16 @@ parameters:
 			message: "#^Parameter \\#3 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Command/CreateScreenshotCommand.php
+
+		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/Command/ListCacheStrategiesCommand.php
+
+		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/DataCollector/PwaCollector.php
 
 		-
 			message: "#^Class SpomkyLabs\\\\PwaBundle\\\\Dto\\\\BackgroundSync has an uninitialized property \\$forceSyncFallback\\. Give it default value or assign it in the constructor\\.$#"
@@ -581,6 +606,16 @@ parameters:
 			path: src/Service/FaviconsCompiler.php
 
 		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/Service/ServiceWorkerCompiler.php
+
+		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/ServiceWorkerRule/AppendCacheStrategies.php
+
+		-
 			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/ServiceWorkerRule/AppendCacheStrategies.php
@@ -594,3 +629,13 @@ parameters:
 			message: "#^Method SpomkyLabs\\\\PwaBundle\\\\SpomkyLabsPwaBundle\\:\\:loadExtension\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/SpomkyLabsPwaBundle.php
+
+		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/Subscriber/FileCompileEventListener.php
+
+		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/Subscriber/PwaDevServerSubscriber.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
     <ini name="intl.error_level" value="0"/>
     <ini name="memory_limit" value="-1"/>
     <server name="KERNEL_CLASS" value="SpomkyLabs\PwaBundle\Tests\AppKernel"/>
+    <server name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
   </php>
   <source>
     <include>

--- a/templates/Collector/serviceworker-tab.html.twig
+++ b/templates/Collector/serviceworker-tab.html.twig
@@ -128,7 +128,7 @@
     </tr>
     </thead>
     <tbody>
-    {% for cachingStrategy in collector.cachingStrategies %}
+    {% for id, cachingStrategy in collector.cachingStrategies %}
         <tr>
             <td>{{ cachingStrategy.getName() }}</td>
             <td class="break-long-words font-normal">
@@ -163,6 +163,20 @@
                 {% endif %}
             </td>
         </tr>
+        {% if preloadedUrls > 0 %}
+            <tr>
+                <td colspan="5">
+                    <div>
+                        <a class="btn btn-link text-small sf-toggle sf-toggle-off" data-toggle-selector="#data-serialize-{{ id }}" data-toggle-alt-content="Hide preloaded URLs" data-toggle-original-content="Show preloaded URLs">
+                            Show preloaded URLs
+                        </a>
+                        <div id="data-serialize-{{ id }}" class="context sf-toggle-content sf-toggle-hidden">
+                            {{ dump(cachingStrategy.preloadUrls) }}
+                        </div>
+                    </div>
+                </td>
+            </tr>
+        {% endif %}
     {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
The ServiceWorker tab in the Collector template now includes an option to show preloaded URLs for each caching strategy. This additional information aids in debugging and analysis, by providing visibility into preloaded URLs at a per-strategy level.

Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
