### PR TITLE
Refactor file compiler services to use iterable

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,11 @@ parameters:
 			path: src/CachingStrategy/AssetCache.php
 
 		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/CachingStrategy/BackgroundSync.php
+
+		-
 			message: "#^Only iterables can be unpacked, mixed given in argument \\#1\\.$#"
 			count: 1
 			path: src/CachingStrategy/FontCache.php
@@ -34,6 +39,16 @@ parameters:
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 2
 			path: src/CachingStrategy/FontCache.php
+
+		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/CachingStrategy/PreloadUrlsGeneratorManager.php
+
+		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/CachingStrategy/ResourceCaches.php
 
 		-
 			message: "#^Only iterables can be unpacked, mixed given in argument \\#1\\.$#"
@@ -119,6 +134,16 @@ parameters:
 			message: "#^Parameter \\#3 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Command/CreateScreenshotCommand.php
+
+		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/Command/ListCacheStrategiesCommand.php
+
+		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/DataCollector/PwaCollector.php
 
 		-
 			message: "#^Class SpomkyLabs\\\\PwaBundle\\\\Dto\\\\BackgroundSync has an uninitialized property \\$forceSyncFallback\\. Give it default value or assign it in the constructor\\.$#"
@@ -581,6 +606,16 @@ parameters:
 			path: src/Service/FaviconsCompiler.php
 
 		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/Service/ServiceWorkerCompiler.php
+
+		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/ServiceWorkerRule/AppendCacheStrategies.php
+
+		-
 			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/ServiceWorkerRule/AppendCacheStrategies.php
@@ -594,3 +629,13 @@ parameters:
 			message: "#^Method SpomkyLabs\\\\PwaBundle\\\\SpomkyLabsPwaBundle\\:\\:loadExtension\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/SpomkyLabsPwaBundle.php
+
+		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/Subscriber/FileCompileEventListener.php
+
+		-
+			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
+			count: 1
+			path: src/Subscriber/PwaDevServerSubscriber.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
     <ini name="intl.error_level" value="0"/>
     <ini name="memory_limit" value="-1"/>
     <server name="KERNEL_CLASS" value="SpomkyLabs\PwaBundle\Tests\AppKernel"/>
+    <server name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
   </php>
   <source>
     <include>

--- a/src/DataCollector/PwaCollector.php
+++ b/src/DataCollector/PwaCollector.php
@@ -66,29 +66,24 @@ final class PwaCollector extends DataCollector
         $this->data['serviceWorker'] = [
             'enabled' => $this->serviceWorker->enabled,
             'data' => $this->serviceWorker,
-            'files' => $swFiles,
+            'files' => $this->dataToFiles($swFiles),
         ];
         $manifestFiles = $this->manifestCompiler->getFiles();
+        $manifestFiles = is_array($manifestFiles) ? $manifestFiles : iterator_to_array($manifestFiles);
         $this->data['manifest'] = [
             'enabled' => $this->serviceWorker->enabled,
             'data' => $this->manifest,
             'installable' => $this->isInstallable(),
             'output' => $this->serializer->serialize($this->manifest, 'json', $jsonOptions),
-            'files' => $manifestFiles,
+            'files' => $this->dataToFiles($manifestFiles),
         ];
 
         $faviconsFiles = $this->faviconsCompiler->getFiles();
+        $faviconsFiles = is_array($faviconsFiles) ? $faviconsFiles : iterator_to_array($faviconsFiles);
         $this->data['favicons'] = [
             'enabled' => $this->favicons->enabled,
             'data' => $this->favicons,
-            'files' => array_map(
-                static fn (\SpomkyLabs\PwaBundle\Service\Data $data): array => [
-                    'url' => $data->url,
-                    'headers' => $data->headers,
-                    'html' => $data->html,
-                ],
-                $faviconsFiles
-            ),
+            'files' => $this->dataToFiles($faviconsFiles),
         ];
     }
 
@@ -155,6 +150,22 @@ final class PwaCollector extends DataCollector
     public function getName(): string
     {
         return 'pwa';
+    }
+
+    /**
+     * @param \SpomkyLabs\PwaBundle\Service\Data[] $data
+     * @return array{url: string, html: string|null, headers: array<string, string|bool>}[]
+     */
+    private function dataToFiles(array $data): array
+    {
+        return array_map(
+            static fn (\SpomkyLabs\PwaBundle\Service\Data $data): array => [
+                'url' => $data->url,
+                'headers' => $data->headers,
+                'html' => $data->html,
+            ],
+            $data
+        );
     }
 
     /**

--- a/src/Service/FileCompilerInterface.php
+++ b/src/Service/FileCompilerInterface.php
@@ -7,7 +7,7 @@ namespace SpomkyLabs\PwaBundle\Service;
 interface FileCompilerInterface
 {
     /**
-     * @return iterable<string, Data>
+     * @return iterable<Data>
      */
     public function getFiles(): iterable;
 }


### PR DESCRIPTION
The file compiler services have been refactored to use iterable instead of arrays. This includes the FaviconsCompiler, ManifestCompiler, and ServiceWorkerCompiler. Now, the getFiles() method of these services returns iterable<Data>, which improves the application's efficiency by avoiding the need to load all the data into memory at once.

Target branch: 1.2.x
Resolves issue #213

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
