### PR TITLE
Update method return types and yield statements

### DIFF
--- a/src/Service/FaviconsCompiler.php
+++ b/src/Service/FaviconsCompiler.php
@@ -32,7 +32,7 @@ final class FaviconsCompiler implements FileCompilerInterface, CanLogInterface
     }
 
     /**
-     * @return iterable<Data>
+     * @return iterable<string, Data>
      */
     public function getFiles(): iterable
     {
@@ -234,14 +234,15 @@ final class FaviconsCompiler implements FileCompilerInterface, CanLogInterface
             );
             $completeHash = hash('xxh128', $hash . $configuration);
             $filename = sprintf($size['url'], $size['width'], $size['height'], $completeHash);
-            yield $this->processIcon($asset, $filename, $configuration, $size['mimetype'], $size['rel']);
+            yield $filename => $this->processIcon($asset, $filename, $configuration, $size['mimetype'], $size['rel']);
         }
         if ($this->favicons->tileColor !== null) {
             $this->logger->debug('Creating browserconfig.xml.');
             yield from $this->processBrowserConfig($asset, $hash);
         }
         if ($this->favicons->safariPinnedTabColor !== null && $this->favicons->useSilhouette === true) {
-            yield $this->generateSafariPinnedTab($asset, $hash);
+            $safariPinnedTab = $this->generateSafariPinnedTab($asset, $hash);
+            yield $safariPinnedTab->url => $safariPinnedTab;
         }
         $this->logger->debug('Favicons created.');
     }
@@ -400,17 +401,17 @@ XML;
         );
 
         return [
-            $icon70x70,
-            $icon150x150,
-            $icon310x310,
-            $icon310x150,
-            Data::create(
+            $icon70x70->url => $icon70x70,
+            $icon150x150->url => $icon150x150,
+            $icon310x310->url => $icon310x310,
+            $icon310x150->url => $icon310x150,
+            $icon144x144->url => Data::create(
                 $icon144x144->url,
                 $icon144x144->getRawData(),
                 $icon144x144->headers,
                 sprintf('<meta name="msapplication-TileImage" content="%s">', $icon144x144->url)
             ),
-            $browserConfig,
+            $browserConfig->url => $browserConfig,
         ];
     }
 

--- a/src/Service/FileCompilerInterface.php
+++ b/src/Service/FileCompilerInterface.php
@@ -7,7 +7,7 @@ namespace SpomkyLabs\PwaBundle\Service;
 interface FileCompilerInterface
 {
     /**
-     * @return iterable<Data>
+     * @return iterable<string, Data>
      */
     public function getFiles(): iterable;
 }

--- a/src/Service/ManifestCompiler.php
+++ b/src/Service/ManifestCompiler.php
@@ -66,7 +66,7 @@ final class ManifestCompiler implements FileCompilerInterface, CanLogInterface
     }
 
     /**
-     * @return iterable<Data>
+     * @return iterable<string, Data>
      */
     public function getFiles(): iterable
     {
@@ -81,13 +81,15 @@ final class ManifestCompiler implements FileCompilerInterface, CanLogInterface
         }
         if ($this->locales === []) {
             $this->logger->debug('No locale defined. Compiling default manifest.');
-            yield $this->compileManifest(null);
+            $manifest = $this->compileManifest(null);
+            yield $manifest->url => $manifest;
         }
         foreach ($this->locales as $locale) {
             $this->logger->debug('Compiling manifest for locale.', [
                 'locale' => $locale,
             ]);
-            yield $this->compileManifest($locale);
+            $manifest = $this->compileManifest($locale);
+            yield $manifest->url => $manifest;
         }
         $this->logger->debug('Manifest files compiled.');
     }

--- a/src/Service/ServiceWorkerCompiler.php
+++ b/src/Service/ServiceWorkerCompiler.php
@@ -53,11 +53,12 @@ final class ServiceWorkerCompiler implements FileCompilerInterface, CanLogInterf
     }
 
     /**
-     * @return iterable<Data>
+     * @return iterable<string, Data>
      */
     public function getFiles(): iterable
     {
-        yield $this->compileSW();
+        $sw = $this->compileSW();
+        yield $sw->url => $sw;
         yield from $this->getWorkboxFiles();
     }
 
@@ -118,7 +119,7 @@ final class ServiceWorkerCompiler implements FileCompilerInterface, CanLogInterf
     }
 
     /**
-     * @return iterable<Data>
+     * @return iterable<string, Data>
      */
     private function getWorkboxFiles(): iterable
     {
@@ -150,7 +151,7 @@ final class ServiceWorkerCompiler implements FileCompilerInterface, CanLogInterf
             if ($data === null) {
                 continue;
             }
-            yield $data;
+            yield $data->url => $data;
         }
     }
 


### PR DESCRIPTION
The methods' return types have been updated from iterable<Data> to iterable<string, Data> in several files, namely FaviconsCompiler.php, ManifestCompiler.php, FileCompilerInterface.php, and ServiceWorkerCompiler.php. Moreover, yield statements have been modified to yield a pair of string (URL) and Data instead of just Data to enhance data identification and access.

Target branch: 1.2.x
Resolves issue #216 

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
