### PR TITLE
Add nonce support to PwaRuntime

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -431,6 +431,21 @@ parameters:
 			path: src/ImageProcessor/GDImageProcessor.php
 
 		-
+			message: "#^Parameter \\#2 \\$red of function imagecolorallocate expects int\\<0, 255\\>, int given\\.$#"
+			count: 1
+			path: src/ImageProcessor/GDImageProcessor.php
+
+		-
+			message: "#^Parameter \\#3 \\$green of function imagecolorallocate expects int\\<0, 255\\>, int given\\.$#"
+			count: 1
+			path: src/ImageProcessor/GDImageProcessor.php
+
+		-
+			message: "#^Parameter \\#4 \\$blue of function imagecolorallocate expects int\\<0, 255\\>, int given\\.$#"
+			count: 1
+			path: src/ImageProcessor/GDImageProcessor.php
+
+		-
 			message: "#^Should not use node with type \"Stmt_Echo\", please change the code\\.$#"
 			count: 3
 			path: src/ImageProcessor/GDImageProcessor.php
@@ -639,3 +654,18 @@ parameters:
 			message: "#^Attribute class Symfony\\\\Component\\\\DependencyInjection\\\\Attribute\\\\TaggedIterator is deprecated\\: since Symfony 7\\.1, use \\{@see AutowireIterator\\} instead\\.$#"
 			count: 1
 			path: src/Subscriber/PwaDevServerSubscriber.php
+
+		-
+			message: "#^Call to method getNonce\\(\\) on an unknown class Nelmio\\\\SecurityBundle\\\\EventListener\\\\ContentSecurityPolicyListener\\.$#"
+			count: 1
+			path: src/Twig/PwaRuntime.php
+
+		-
+			message: "#^Parameter \\$cspListener of method SpomkyLabs\\\\PwaBundle\\\\Twig\\\\PwaRuntime\\:\\:__construct\\(\\) has invalid type Nelmio\\\\SecurityBundle\\\\EventListener\\\\ContentSecurityPolicyListener\\.$#"
+			count: 1
+			path: src/Twig/PwaRuntime.php
+
+		-
+			message: "#^Property SpomkyLabs\\\\PwaBundle\\\\Twig\\\\PwaRuntime\\:\\:\\$cspListener has unknown class Nelmio\\\\SecurityBundle\\\\EventListener\\\\ContentSecurityPolicyListener as its type\\.$#"
+			count: 1
+			path: src/Twig/PwaRuntime.php


### PR DESCRIPTION
The update includes the use of Nelmio SecurityBundle for Content Security Policy management. Specifically, it checks if the 'nonce' attribute exists in the PwaRuntime and if not, it retrieves a nonce from ContentSecurityPolicyListener for 'script'. This ensures the secure execution of scripts. In addition, if the 'nonce' attribute is set with the value 'false', the attribute is disabled.

Target branch: 1.3.x
Resolves issue #220 

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
