### PR TITLE
explicitly declare implicit nullable parameter declarations

### DIFF
--- a/src/DataCollector/PwaCollector.php
+++ b/src/DataCollector/PwaCollector.php
@@ -48,7 +48,7 @@ final class PwaCollector extends DataCollector
     ) {
     }
 
-    public function collect(Request $request, Response $response, Throwable $exception = null): void
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
     {
         $jsonOptions = [
             AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES => true,

--- a/src/Normalizer/AssetNormalizer.php
+++ b/src/Normalizer/AssetNormalizer.php
@@ -21,7 +21,7 @@ final readonly class AssetNormalizer implements NormalizerInterface, Denormalize
     /**
      * @return array{src: string, sizes?: string, form_factor?: string, label?: string, platform?: string, format?: string}
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): string
+    public function normalize(mixed $object, ?string $format = null, array $context = []): string
     {
         assert($object instanceof Asset);
         $url = null;
@@ -36,14 +36,14 @@ final readonly class AssetNormalizer implements NormalizerInterface, Denormalize
         return $url;
     }
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         assert(is_string($data));
 
         return Asset::create($data);
     }
 
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof Asset;
     }
@@ -51,7 +51,7 @@ final readonly class AssetNormalizer implements NormalizerInterface, Denormalize
     public function supportsDenormalization(
         mixed $data,
         string $type,
-        string $format = null,
+        ?string $format = null,
         array $context = []
     ): bool {
         return $type === Asset::class;

--- a/src/Normalizer/IconNormalizer.php
+++ b/src/Normalizer/IconNormalizer.php
@@ -23,7 +23,7 @@ final class IconNormalizer implements NormalizerInterface, NormalizerAwareInterf
     /**
      * @return array{src: string, sizes?: string, type?: string, purpose?: string}
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): array
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array
     {
         assert($object instanceof Icon);
         $icon = $this->iconResolver->getIcon($object);
@@ -44,7 +44,7 @@ final class IconNormalizer implements NormalizerInterface, NormalizerAwareInterf
         return $cleanup($result);
     }
 
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof Icon;
     }

--- a/src/Normalizer/ScreenshotNormalizer.php
+++ b/src/Normalizer/ScreenshotNormalizer.php
@@ -28,7 +28,7 @@ final class ScreenshotNormalizer implements NormalizerInterface, NormalizerAware
     /**
      * @return array{src: string, sizes?: string, form_factor?: string, label?: string, platform?: string, format?: string}
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): array
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array
     {
         assert($object instanceof Screenshot);
         $asset = null;
@@ -55,7 +55,7 @@ final class ScreenshotNormalizer implements NormalizerInterface, NormalizerAware
         return $cleanup($result);
     }
 
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof Screenshot;
     }

--- a/src/Normalizer/ServiceWorkerNormalizer.php
+++ b/src/Normalizer/ServiceWorkerNormalizer.php
@@ -13,7 +13,7 @@ final readonly class ServiceWorkerNormalizer implements NormalizerInterface
     /**
      * @return array{scope?: string, src: string, use_cache?: bool}
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): array
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array
     {
         assert($object instanceof ServiceWorker);
 
@@ -30,7 +30,7 @@ final readonly class ServiceWorkerNormalizer implements NormalizerInterface
         return $cleanup($result);
     }
 
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof ServiceWorker;
     }

--- a/src/Normalizer/UrlNormalizer.php
+++ b/src/Normalizer/UrlNormalizer.php
@@ -24,7 +24,7 @@ final class UrlNormalizer implements NormalizerInterface, NormalizerAwareInterfa
     ) {
     }
 
-    public function normalize(mixed $object, string $format = null, array $context = []): string
+    public function normalize(mixed $object, ?string $format = null, array $context = []): string
     {
         assert($object instanceof Url);
 
@@ -48,7 +48,7 @@ final class UrlNormalizer implements NormalizerInterface, NormalizerAwareInterfa
         }
     }
 
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof Url;
     }


### PR DESCRIPTION
Target branch: 1.3.x

- [ x] Includes Deprecations

This PR gets rid of the deprecation warnings and makes the bundle one step closer to working in php 8.4
