### PR TITLE
Add ExplicitNullableParamTypeRector to Rector config

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector;
 use Rector\Doctrine\Set\DoctrineSetList;
+use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
@@ -15,13 +16,11 @@ return static function (RectorConfig $config): void {
     $config->sets([
         SetList::DEAD_CODE,
         LevelSetList::UP_TO_PHP_82,
-        //SymfonySetList::SYMFONY_63,
         SymfonySetList::SYMFONY_CODE_QUALITY,
         SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,
         DoctrineSetList::DOCTRINE_CODE_QUALITY,
         DoctrineSetList::DOCTRINE_ORM_214,
         DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES,
-        //PHPUnitSetList::PHPUNIT_100,
         PHPUnitSetList::PHPUNIT_CODE_QUALITY,
         PHPUnitSetList::ANNOTATIONS_TO_ATTRIBUTES,
     ]);
@@ -29,6 +28,7 @@ return static function (RectorConfig $config): void {
     $config->paths(
         [__DIR__ . '/src', __DIR__ . '/tests', __DIR__ . '/castor.php', __DIR__ . '/ecs.php', __DIR__ . '/rector.php']
     );
+    $config->rule(ExplicitNullableParamTypeRector::class);
     $config->skip([
         RemoveEmptyClassMethodRector::class => [__DIR__ . '/tests/Controller/'],
     ]);


### PR DESCRIPTION
Updated the Rector configuration to include the ExplicitNullableParamTypeRector rule. This ensures stricter type definitions for nullable parameters, improving code quality and clarity. Removed commented-out legacy set lists for cleaner configuration.
