### PR TITLE
Update event names to use 'pwa' namespace and add screen capture

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -103,6 +103,13 @@
                 "fetch": "eager",
                 "enabled": true
             },
+            "screen-capture": {
+                "main": "src/screen-capture_controller.js",
+                "name": "pwa/screen-capture",
+                "webpackMode": "eager",
+                "fetch": "eager",
+                "enabled": true
+            },
             "speech-synthesis": {
                 "main": "src/speech-synthesis_controller.js",
                 "name": "pwa/speech-synthesis",

--- a/assets/src/badge_controller.js
+++ b/assets/src/badge_controller.js
@@ -6,11 +6,11 @@ import AbstractController from './abstract_controller.js';
 export default class extends AbstractController {
     update = async ({counter}) => {
         await navigator.setAppBadge(counter);
-        this.dispatchEvent('badge:updated', { counter });
+        this.dispatchEvent('pwa:badge:updated', { counter });
     }
 
     clear = async () => {
         await navigator.clearAppBadge();
-        this.dispatchEvent('badge:cleared');
+        this.dispatchEvent('pwa:badge:cleared');
     }
 }

--- a/assets/src/battery_controller.js
+++ b/assets/src/battery_controller.js
@@ -18,19 +18,19 @@ export default class extends AbstractController {
     }
     update = async ({counter}) => {
         await navigator.setAppBadge(counter);
-        this.dispatchEvent('battery:updated', { counter });
+        this.dispatchEvent('pwa:battery:updated', { counter });
     }
 
     updateChargeInfo = async (battery) => {
-        this.dispatchEvent('battery:charge', { charging: battery.charging });
+        this.dispatchEvent('pwa:battery:charge', { charging: battery.charging });
     }
     updateLevelInfo = async (battery) => {
-        this.dispatchEvent('battery:level', { level: battery.level });
+        this.dispatchEvent('pwa:battery:level', { level: battery.level });
     }
     updateChargingInfo = async (battery) => {
-        this.dispatchEvent('battery:chargingtime', { chargingTime: battery.chargingTime });
+        this.dispatchEvent('pwa:battery:chargingtime', { chargingTime: battery.chargingTime });
     }
     updateDischargingInfo = async (battery) => {
-        this.dispatchEvent('battery:dischargingtime', { dischargingTime: battery.dischargingTime });
+        this.dispatchEvent('pwa:battery:dischargingtime', { dischargingTime: battery.dischargingTime });
     }
 }

--- a/assets/src/connection-status_controller.js
+++ b/assets/src/connection-status_controller.js
@@ -11,7 +11,7 @@ export default class extends AbstractController {
     };
 
     connect = () => {
-        this.dispatchEvent('connection-status:connect', {});
+        this.dispatchEvent('pwa:connection-status:connect', {});
         if (navigator.onLine) {
             this.statusChanged({
                 status: 'ONLINE',
@@ -45,6 +45,6 @@ export default class extends AbstractController {
         this.attributeTargets.forEach((element) => {
             element.setAttribute('data-connection-status', data.status);
         });
-        this.dispatchEvent('connection-status:changed', { detail: data });
+        this.dispatchEvent('pwa:connection-status:changed', { detail: data });
     }
 }

--- a/assets/src/device-motion_controller.js
+++ b/assets/src/device-motion_controller.js
@@ -22,7 +22,7 @@ export default class extends AbstractController {
         };
 
         const dispatchMotionEvent = (event) => {
-            this.dispatchEvent('device:motion', {
+            this.dispatchEvent('pwa:device:motion', {
                 acceleration: event.acceleration,
                 accelerationIncludingGravity: event.accelerationIncludingGravity,
                 rotationRate: event.rotationRate,

--- a/assets/src/device-orientation_controller.js
+++ b/assets/src/device-orientation_controller.js
@@ -22,7 +22,7 @@ export default class extends AbstractController {
         };
 
         const dispatchOrientationEvent = (event) => {
-            this.dispatchEvent('device:orientation', {
+            this.dispatchEvent('pwa:device:orientation', {
                 absolute: event.absolute,
                 alpha: event.alpha,
                 beta: event.beta,

--- a/assets/src/fullscreen_controller.js
+++ b/assets/src/fullscreen_controller.js
@@ -6,13 +6,13 @@ import AbstractController from './abstract_controller.js';
 export default class extends AbstractController {
     connect () {
         document.addEventListener("fullscreenchange", () => {
-            this.dispatchEvent('fullscreen:change', {
+            this.dispatchEvent('pwa:fullscreen:change', {
                 fullscreen: document.fullscreenElement !== null,
                 element: document.fullscreenElement
             });
         });
         document.addEventListener("fullscreenerror", () => {
-            this.dispatchEvent('fullscreen:error', {
+            this.dispatchEvent('pwa:fullscreen:error', {
                 element: document.fullscreenElement
             });
         });

--- a/assets/src/geolocation_controller.js
+++ b/assets/src/geolocation_controller.js
@@ -8,20 +8,20 @@ export default class extends AbstractController {
 
     locate({params}) {
         if (!navigator.geolocation) {
-            this.dispatchEvent('geolocation:unsupported');
+            this.dispatchEvent('pwa:geolocation:unsupported');
             return;
         }
 
         navigator.geolocation.getCurrentPosition(
-            (position) => {this.dispatchEvent('geolocation:position', {position});},
-            (error) => {this.dispatchEvent('geolocation:error', {error: error});},
+            (position) => {this.dispatchEvent('pwa:geolocation:position', {position});},
+            (error) => {this.dispatchEvent('pwa:geolocation:error', {error: error});},
             params
         );
     }
 
     watch({params}) {
         if (!navigator.geolocation) {
-            this.dispatchEvent('geolocation:unsupported');
+            this.dispatchEvent('pwa:geolocation:unsupported');
             return;
         }
         if (this.watchId) {
@@ -29,8 +29,8 @@ export default class extends AbstractController {
         }
 
         this.watchId = navigator.geolocation.watchPosition(
-            (position) => {this.dispatchEvent('geolocation:position', {position});},
-            (error) => {this.dispatchEvent('geolocation:error', {error});},
+            (position) => {this.dispatchEvent('pwa:geolocation:position', {position});},
+            (error) => {this.dispatchEvent('pwa:geolocation:error', {error});},
             params
         );
     }
@@ -42,6 +42,6 @@ export default class extends AbstractController {
 
         navigator.geolocation.clearWatch(this.watchId);
         this.watchId = null;
-        this.dispatchEvent('geolocation:watch:cleared');
+        this.dispatchEvent('pwa:geolocation:watch:cleared');
     }
 }

--- a/assets/src/install_controller.js
+++ b/assets/src/install_controller.js
@@ -25,6 +25,7 @@ export default class extends AbstractController {
             this.disableInstallTargets();
         } else {
             this.dispatchEvent('install:cancelled');
+            this.dispatchEvent('pwa:install:cancelled');
         }
     }
 

--- a/assets/src/network-information_controller.js
+++ b/assets/src/network-information_controller.js
@@ -12,6 +12,6 @@ export default class extends Controller {
   updateConnectionStatus = () => {
     const connection = navigator.connection;
     console.log({bubble: true, details: connection});
-    this.dispatch('network-information:change', {bubble: true, details: {connection}});
+    this.dispatch('pwa:network-information:change', {bubble: true, details: {connection}});
   }
 }

--- a/assets/src/prefetch-on-demand_controller.js
+++ b/assets/src/prefetch-on-demand_controller.js
@@ -20,5 +20,9 @@ export default class extends AbstractController {
             result === true ?'prefetch:prefetched': 'prefetch:error',
             {params}
         );
+        this.dispatchEvent(
+            result === true ?'pwa:prefetch:prefetched': 'pwa:prefetch:error',
+            {params}
+        );
     }
 }

--- a/assets/src/presentation_controller.js
+++ b/assets/src/presentation_controller.js
@@ -13,9 +13,9 @@ export default class extends AbstractController {
     async connect() {
         this.request = new PresentationRequest(this.urlsValue);
         const availability = await this.request.getAvailability();
-        this.dispatchEvent('presentation:availability:changed', { availability });
+        this.dispatchEvent('pwa:presentation:availability:changed', { availability });
         availability.onchange = () => {
-            this.dispatchEvent('presentation:availability:changed', { availability });
+            this.dispatchEvent('pwa:presentation:availability:changed', { availability });
         }
     }
 
@@ -53,7 +53,7 @@ export default class extends AbstractController {
         this.connection.terminate();
         this.connection = null;
         localStorage.removeItem('presentation_connection_id');
-        this.dispatchEvent('presentation:terminated', {id});
+        this.dispatchEvent('pwa:presentation:terminated', {id});
     }
 
     setConnection(connection) {
@@ -63,6 +63,6 @@ export default class extends AbstractController {
 
         this.connection = connection;
         localStorage.setItem('presentation_connection_id', connection.id);
-        this.dispatchEvent('presentation:started', {id: connection.id});
+        this.dispatchEvent('pwa:presentation:started', {id: connection.id});
     }
 }

--- a/assets/src/receiver_controller.js
+++ b/assets/src/receiver_controller.js
@@ -17,13 +17,13 @@ export default class extends AbstractController {
             'message',
             (event) => {
                 const data = JSON.parse(event.data);
-                this.dispatchEvent('receiver:message', {data});
+                this.dispatchEvent('pwa:receiver:message', {data});
             }
         );
 
         connection.addEventListener(
             'close',
-            (event) => this.dispatchEvent('receiver:close', {
+            (event) => this.dispatchEvent('pwa:receiver:close', {
                 connectionId: connection.connectionId,
                 reason: event.reason,
                 message: event.message

--- a/assets/src/screen-capture_controller.js
+++ b/assets/src/screen-capture_controller.js
@@ -1,0 +1,69 @@
+'use strict';
+
+import AbstractController from './abstract_controller.js';
+
+/* stimulusFetch: 'lazy' */
+export default class extends AbstractController {
+    getSupportedConstraints = async() => {
+        try {
+            this._checkSupported();
+            const constraints = navigator.mediaDevices.getSupportedConstraints();
+            this.dispatchEvent('pwa:screen-capture:constraints', {constraints});
+        } catch (error) {
+            this.dispatchEvent('pwa:screen-capture:error', {error});
+        }
+    }
+
+    capture = async({params}) => {
+        try {
+            this._checkScreenCaptureSupported();
+            const stream = await navigator.mediaDevices.getDisplayMedia({
+                video: params.videoConstraints ?? true,
+                audio: params.audioConstraints ?? false,
+            });
+            const tracks = stream.getTracks();
+            if (tracks.length === 0) {
+                throw "No tracks found";
+            }
+            tracks.forEach((track) => {
+                track.addEventListener('ended', () => {
+                    window.recorder.stop();
+                });
+            })
+
+            const chunks = [];
+            window.recorder = new MediaRecorder(stream);
+            window.recorder.addEventListener('dataavailable', (event) => {
+                if (event.data.size <= 0) {
+                    return;
+                }
+                chunks.push(event.data);
+            })
+
+            window.recorder.addEventListener('stop', () => {
+                const file = new File(chunks, 'video.mp4', {type: 'video/mp4'});
+                const exportUrl  = URL.createObjectURL(file);
+                this.dispatchEvent('pwa:screen-capture:available', {exportUrl});
+            });
+            window.recorder.addEventListener('start', () => {
+                const info = tracks.map((track) => {
+                    return {
+                        capabilities: track.getCapabilities(),
+                        settings: track.getSettings()
+                    };
+                });
+                this.dispatchEvent('pwa:screen-capture:started', info);
+            });
+
+            window.recorder.start();
+        } catch (error) {
+            this.dispatchEvent('pwa:screen-capture:error', {error});
+        }
+    }
+
+    _checkScreenCaptureSupported = () => {
+        if (!navigator.mediaDevices.getDisplayMedia) {
+            throw "Your device does not support the Screen Capture API";
+        }
+    }
+}

--- a/assets/src/share_controller.js
+++ b/assets/src/share_controller.js
@@ -16,7 +16,7 @@ export default class extends AbstractController {
                 return;
             }
             await navigator.share(data);
-            this.dispatchEvent('share:success', {data});
+            this.dispatchEvent('pwa:share:success', {data});
         } catch (error) {
             console.error("Error sharing", {error});
         }

--- a/assets/src/sync-broadcast_controller.js
+++ b/assets/src/sync-broadcast_controller.js
@@ -30,6 +30,6 @@ export default class extends AbstractController {
         this.remainingTargets.forEach((element) => {
             element.innerHTML = data.remaining;
         });
-        this.dispatchEvent('sync-broadcast:status-changed', { detail: data });
+        this.dispatchEvent('pwa:sync-broadcast:status-changed', { detail: data });
     }
 }

--- a/assets/src/touch_controller.js
+++ b/assets/src/touch_controller.js
@@ -26,9 +26,9 @@ export default class extends AbstractController {
         for (let i = 0; i < changedTouches.length; i++) {
             const idx = this.ongoingTouchIndexById(changedTouches[i].identifier);
             this.ongoingTouches.splice(idx, 1);
-            this.dispatchEvent('touch:ended', { touch: changedTouches[i], bubbles: true });
+            this.dispatchEvent('pwa:touch:ended', { touch: changedTouches[i], bubbles: true });
         }
-        this.dispatchEvent('touch:updated', { touches: this.ongoingTouches, bubbles: true });
+        this.dispatchEvent('pwa:touch:updated', { touches: this.ongoingTouches, bubbles: true });
     }
 
     onTouchCancel = (event) => {
@@ -37,9 +37,9 @@ export default class extends AbstractController {
         for (let i = 0; i < changedTouches.length; i++) {
             const idx = this.ongoingTouchIndexById(changedTouches[i].identifier);
             this.ongoingTouches.splice(idx, 1);
-            this.dispatchEvent('touch:cancelled', { touch: changedTouches[i], bubbles: true });
+            this.dispatchEvent('pwa:touch:cancelled', { touch: changedTouches[i], bubbles: true });
         }
-        this.dispatchEvent('touch:updated', { touches: this.ongoingTouches, bubbles: true });
+        this.dispatchEvent('pwa:touch:updated', { touches: this.ongoingTouches, bubbles: true });
     }
 
     onTouchMove = (event) => {
@@ -48,9 +48,9 @@ export default class extends AbstractController {
         for (let i = 0; i < changedTouches.length; i++) {
             const idx = this.ongoingTouchIndexById(changedTouches[i].identifier);
             this.ongoingTouches.splice(idx, 1, this.copyTouch(changedTouches[i]))
-            this.dispatchEvent('touch:moved', { touch: changedTouches[i], bubbles: true });
+            this.dispatchEvent('pwa:touch:moved', { touch: changedTouches[i], bubbles: true });
         }
-        this.dispatchEvent('touch:updated', { touches: this.ongoingTouches, bubbles: true });
+        this.dispatchEvent('pwa:touch:updated', { touches: this.ongoingTouches, bubbles: true });
     }
 
     onTouchStart = (event) => {
@@ -58,9 +58,9 @@ export default class extends AbstractController {
         const {changedTouches} = event;
         for (let i = 0; i < changedTouches.length; i++) {
             this.ongoingTouches.push(this.copyTouch(changedTouches[i]));
-            this.dispatchEvent('touch:started', { touch: changedTouches[i], bubbles: true });
+            this.dispatchEvent('pwa:touch:started', { touch: changedTouches[i], bubbles: true });
         }
-        this.dispatchEvent('touch:updated', { touches: this.ongoingTouches, bubbles: true });
+        this.dispatchEvent('pwa:touch:updated', { touches: this.ongoingTouches, bubbles: true });
     }
 
     ongoingTouchIndexById = (idToFind) => {

--- a/assets/src/vibration_controller.js
+++ b/assets/src/vibration_controller.js
@@ -13,7 +13,7 @@ export default class extends AbstractController {
             return;
         }
         await navigator.vibrate(sequence);
-        this.dispatchEvent('vibration:triggered', { sequence });
+        this.dispatchEvent('pwa:vibration:triggered', { sequence });
     }
 
     persistent = async ({params}) => {
@@ -40,6 +40,6 @@ export default class extends AbstractController {
         }
         clearInterval(this.vibrateInterval);
         this.vibrateInterval = null;
-        this.dispatchEvent('vibration:stopped');
+        this.dispatchEvent('pwa:vibration:stopped');
     }
 }


### PR DESCRIPTION

Target branch: 1.3.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations
- [ ] 
Standardized all dispatched event names to include the 'pwa' prefix for consistency. Introduced a new screen capture controller with methods to initiate and handle media capture using the Screen Capture API. These changes improve event clarity and extend functionality.
