### PR TITLE
Update command descriptions to mark deprecated commands

### DIFF
--- a/src/Command/CreateIconsCommand.php
+++ b/src/Command/CreateIconsCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Yaml\Yaml;
 use function is_string;
 use function sprintf;
 
-#[AsCommand(name: 'pwa:create:icons', description: 'Generate icons for your PWA')]
+#[AsCommand(name: 'pwa:create:icons', description: '[DEPRECATED] Generate icons for your PWA')]
 final class CreateIconsCommand extends Command
 {
     public function __construct(

--- a/src/Command/CreateScreenshotCommand.php
+++ b/src/Command/CreateScreenshotCommand.php
@@ -28,7 +28,7 @@ use function sprintf;
 
 #[AsCommand(
     name: 'pwa:create:screenshot',
-    description: 'Take a screenshot of the application store it in your asset folder'
+    description: '[DEPRECATED] Take a screenshot of the application store it in your asset folder'
 )]
 final class CreateScreenshotCommand extends Command
 {

--- a/src/Command/ListCacheStrategiesCommand.php
+++ b/src/Command/ListCacheStrategiesCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\Yaml\Yaml;
 use function count;
 
-#[AsCommand(name: 'pwa:cache:list-strategies', description: 'List the available cache strategies',)]
+#[AsCommand(name: 'pwa:cache:list-strategies', description: 'List the available cache strategies')]
 final class ListCacheStrategiesCommand extends Command
 {
     /**


### PR DESCRIPTION
Target branch: 1.3

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [x] Includes Deprecations

Marked `pwa:create:icons` and `pwa:create:screenshot` as deprecated in their descriptions.
These commands will be removed in 2.0.0

* `pwa:create:icons` is not needed anymore as icons are created on the fly during the asset compilation.
* `pwa:create:screenshot` is too much work for just simple screenshots updated once or twice.