### PR TITLE
Add support for iOS splash screen startup images

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1023,7 +1023,7 @@ parameters:
 		-
 			message: '#^Cannot call method booleanNode\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 3
+			count: 4
 			path: src/Resources/config/definition/favicons.php
 
 		-
@@ -1051,6 +1051,12 @@ parameters:
 			path: src/Resources/config/definition/favicons.php
 
 		-
+			message: '#^Cannot call method defaultTrue\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/Resources/config/definition/favicons.php
+
+		-
 			message: '#^Cannot call method defaultValue\(\) on mixed\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -1059,7 +1065,7 @@ parameters:
 		-
 			message: '#^Cannot call method end\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 14
+			count: 15
 			path: src/Resources/config/definition/favicons.php
 
 		-
@@ -1071,7 +1077,7 @@ parameters:
 		-
 			message: '#^Cannot call method info\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 10
+			count: 11
 			path: src/Resources/config/definition/favicons.php
 
 		-
@@ -1791,6 +1797,18 @@ parameters:
 		-
 			message: '#^Method SpomkyLabs\\PwaBundle\\Service\\FaviconsCompiler\:\:getFavicon\(\) should return array\{string, string\} but returns array\{string\|false, string\}\.$#'
 			identifier: return.type
+			count: 1
+			path: src/Service/FaviconsCompiler.php
+
+		-
+			message: '#^Offset ''imageScale'' on non\-empty\-array\<literal\-string&non\-falsy\-string, 16\|30\|32\|36\|40\|48\|57\|60\|72\|76\|96\|114\|120\|144\|152\|180\|192\|256\|384\|512\|640\|750\|1125\|1136\|1242\|1294\|1536\|1668\|2048\|2148\|2224\|2436\|2732\|''\(device\-width\:…''\|''\(min\-device\-width\:…''\|''/favicon\.ico''\|''/pwa/favicon\-%%dx%%d\-…''\|''apple\-touch\-icon''\|''apple\-touch\-startup…''\|''ico''\|''icon''\|''image/png''\|''image/x\-icon''\|''png''\> on left side of \?\? does not exist\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: src/Service/FaviconsCompiler.php
+
+		-
+			message: '#^Parameter \#6 \$media of method SpomkyLabs\\PwaBundle\\Service\\FaviconsCompiler\:\:processIcon\(\) expects string\|null, int\|string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Service/FaviconsCompiler.php
 

--- a/src/Dto/Favicons.php
+++ b/src/Dto/Favicons.php
@@ -39,6 +39,9 @@ final class Favicons
     #[SerializedName('use_silhouette')]
     public null|bool $useSilhouette = null;
 
+    #[SerializedName('use_start_image')]
+    public null|bool $useStartImage = null;
+
     public null|string $potrace = null;
 
     public bool $monochrome = false;

--- a/src/Resources/config/definition/favicons.php
+++ b/src/Resources/config/definition/favicons.php
@@ -53,6 +53,10 @@ return static function (DefinitionConfigurator $definition): void {
                             'Use only the silhouette of the icon. Applicable for macOS Safari and Windows 8+. Requires potrace to be installed.'
                         )
                     ->end()
+                    ->booleanNode('use_start_image')
+                        ->defaultTrue()
+                        ->info('Use the icon as a start image for the iOS splash screen.')
+                    ->end()
                     ->booleanNode('monochrome')
                         ->defaultFalse()
                         ->info('Use a monochrome icon.')

--- a/src/Service/FaviconsCompiler.php
+++ b/src/Service/FaviconsCompiler.php
@@ -101,6 +101,155 @@ final class FaviconsCompiler implements FileCompilerInterface, CanLogInterface
                 'rel' => 'icon',
             ],
         ];
+
+        if ($this->favicons->useStartImage === true) {
+            $sizes = [
+                ...$sizes,
+                //Portrait
+                [
+                    'url' => '/pwa/favicon-%dx%d-%s.png',
+                    'width' => 640,
+                    'height' => 1136,
+                    'format' => 'png',
+                    'mimetype' => 'image/png',
+                    'rel' => 'apple-touch-startup-image',
+                    'imageScale' => 40,
+                    'media' => '(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)',
+                ],
+                [
+                    'url' => '/pwa/favicon-%dx%d-%s.png',
+                    'width' => 750,
+                    'height' => 1294,
+                    'format' => 'png',
+                    'mimetype' => 'image/png',
+                    'rel' => 'apple-touch-startup-image',
+                    'imageScale' => 40,
+                    'media' => '(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)',
+                ],
+                [
+                    'url' => '/pwa/favicon-%dx%d-%s.png',
+                    'width' => 1242,
+                    'height' => 2148,
+                    'format' => 'png',
+                    'mimetype' => 'image/png',
+                    'rel' => 'apple-touch-startup-image',
+                    'imageScale' => 40,
+                    'media' => '(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)',
+                ],
+                [
+                    'url' => '/pwa/favicon-%dx%d-%s.png',
+                    'width' => 1125,
+                    'height' => 2436,
+                    'format' => 'png',
+                    'mimetype' => 'image/png',
+                    'rel' => 'apple-touch-startup-image',
+                    'imageScale' => 40,
+                    'media' => '(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)',
+                ],
+                [
+                    'url' => '/pwa/favicon-%dx%d-%s.png',
+                    'width' => 1536,
+                    'height' => 2048,
+                    'format' => 'png',
+                    'mimetype' => 'image/png',
+                    'rel' => 'apple-touch-startup-image',
+                    'imageScale' => 40,
+                    'media' => '(min-device-width: 768px) and (max-device-width: 1024px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)',
+                ],
+                [
+                    'url' => '/pwa/favicon-%dx%d-%s.png',
+                    'width' => 1668,
+                    'height' => 2224,
+                    'format' => 'png',
+                    'mimetype' => 'image/png',
+                    'rel' => 'apple-touch-startup-image',
+                    'imageScale' => 40,
+                    'media' => '(min-device-width: 834px) and (max-device-width: 834px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)',
+                ],
+                [
+                    'url' => '/pwa/favicon-%dx%d-%s.png',
+                    'width' => 2048,
+                    'height' => 2732,
+                    'format' => 'png',
+                    'mimetype' => 'image/png',
+                    'rel' => 'apple-touch-startup-image',
+                    'imageScale' => 40,
+                    'media' => '(min-device-width: 1024px) and (max-device-width: 1024px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)',
+                ],
+                //Landscape
+                [
+                    'url' => '/pwa/favicon-%dx%d-%s.png',
+                    'width' => 1136,
+                    'height' => 640,
+                    'format' => 'png',
+                    'mimetype' => 'image/png',
+                    'rel' => 'apple-touch-startup-image',
+                    'imageScale' => 30,
+                    'media' => '(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)',
+                ],
+                [
+                    'url' => '/pwa/favicon-%dx%d-%s.png',
+                    'width' => 1294,
+                    'height' => 750,
+                    'format' => 'png',
+                    'mimetype' => 'image/png',
+                    'rel' => 'apple-touch-startup-image',
+                    'imageScale' => 30,
+                    'media' => '(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)',
+                ],
+                [
+                    'url' => '/pwa/favicon-%dx%d-%s.png',
+                    'width' => 2148,
+                    'height' => 1242,
+                    'format' => 'png',
+                    'mimetype' => 'image/png',
+                    'rel' => 'apple-touch-startup-image',
+                    'imageScale' => 30,
+                    'media' => '(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)',
+                ],
+                [
+                    'url' => '/pwa/favicon-%dx%d-%s.png',
+                    'width' => 2436,
+                    'height' => 1125,
+                    'format' => 'png',
+                    'mimetype' => 'image/png',
+                    'rel' => 'apple-touch-startup-image',
+                    'imageScale' => 30,
+                    'media' => '(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)',
+                ],
+                [
+                    'url' => '/pwa/favicon-%dx%d-%s.png',
+                    'width' => 2048,
+                    'height' => 1536,
+                    'format' => 'png',
+                    'mimetype' => 'image/png',
+                    'rel' => 'apple-touch-startup-image',
+                    'imageScale' => 30,
+                    'media' => '(min-device-width: 768px) and (max-device-width: 1024px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: landscape)',
+                ],
+                [
+                    'url' => '/pwa/favicon-%dx%d-%s.png',
+                    'width' => 2224,
+                    'height' => 1668,
+                    'format' => 'png',
+                    'mimetype' => 'image/png',
+                    'rel' => 'apple-touch-startup-image',
+                    'imageScale' => 30,
+                    'media' => '(min-device-width: 834px) and (max-device-width: 834px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: landscape)',
+                ],
+                [
+                    'url' => '/pwa/favicon-%dx%d-%s.png',
+                    'width' => 2732,
+                    'height' => 2048,
+                    'format' => 'png',
+                    'mimetype' => 'image/png',
+                    'rel' => 'apple-touch-startup-image',
+                    'imageScale' => 30,
+                    'media' => '(min-device-width: 1024px) and (max-device-width: 1024px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: landscape)',
+                ],
+            ];
+        }
+
         if ($this->favicons->lowResolution === true) {
             $sizes = [
                 ...$sizes,
@@ -231,12 +380,19 @@ final class FaviconsCompiler implements FileCompilerInterface, CanLogInterface
                 $size['format'],
                 $this->favicons->backgroundColor,
                 $this->favicons->borderRadius,
-                $this->favicons->imageScale,
+                $size['imageScale'] ?? $this->favicons->imageScale,
                 $this->favicons->monochrome
             );
             $completeHash = hash('xxh128', $hash . $configuration);
             $filename = sprintf($size['url'], $size['width'], $size['height'], $completeHash);
-            yield $filename => $this->processIcon($asset, $filename, $configuration, $size['mimetype'], $size['rel']);
+            yield $filename => $this->processIcon(
+                $asset,
+                $filename,
+                $configuration,
+                $size['mimetype'],
+                $size['rel'],
+                $size['media'] ?? null
+            );
         }
         if ($this->favicons->tileColor !== null) {
             $this->logger->debug('Creating browserconfig.xml.');
@@ -260,22 +416,25 @@ final class FaviconsCompiler implements FileCompilerInterface, CanLogInterface
         Configuration $configuration,
         string $mimeType,
         null|string $rel,
+        null|string $media = null,
     ): Data {
         $this->logger->debug('Processing icon.', [
             'publicUrl' => $publicUrl,
             'configuration' => $configuration,
             'mimeType' => $mimeType,
             'rel' => $rel,
+            'media' => $media,
         ]);
         $closure = fn (): string => $this->imageProcessor->process($asset, null, null, null, $configuration);
         if ($this->debug === true) {
             $html = $rel === null ? null : sprintf(
-                '<link rel="%s" sizes="%dx%d" type="%s" href="%s">',
+                '<link rel="%s" sizes="%dx%d" type="%s" href="%s"%s>',
                 $rel,
                 $configuration->width,
                 $configuration->height,
                 $mimeType,
-                $publicUrl
+                $publicUrl,
+                $media === null ? '' : sprintf(' media="%s"', $media)
             );
             return Data::create(
                 $publicUrl,

--- a/src/Service/FaviconsCompiler.php
+++ b/src/Service/FaviconsCompiler.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 use function assert;
+use function is_string;
 use function sprintf;
 use const PHP_EOL;
 
@@ -434,7 +435,7 @@ final class FaviconsCompiler implements FileCompilerInterface, CanLogInterface
                 $configuration->height,
                 $mimeType,
                 $publicUrl,
-                $media === null ? '' : sprintf(' media="%s"', $media)
+                is_string($media) ? sprintf(' media="%s"', $media) : ''
             );
             return Data::create(
                 $publicUrl,


### PR DESCRIPTION
Target branch: 1.3
Resolves issue #223 

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Introduced the `use_start_image` option to generate startup images for iOS devices, both in portrait and landscape orientations. Updated related code to handle media queries and configuration specific to these assets. This enhancement improves PWA compatibility and user experience on iOS.
