### PR TITLE
Add locale parameter support in URL generation

### DIFF
--- a/src/Normalizer/UrlNormalizer.php
+++ b/src/Normalizer/UrlNormalizer.php
@@ -41,7 +41,12 @@ final class UrlNormalizer implements NormalizerInterface, NormalizerAwareInterfa
 
         // Otherwise, we try to generate the URL
         try {
-            return $this->router->generate($data->path, $data->params, $data->pathTypeReference);
+            $params = [
+                '_locale' => $context['translatable_normalization_locale'] ?? null,
+                ...$data->params
+            ];
+
+            return $this->router->generate($data->path, $params, $data->pathTypeReference);
         } catch (Throwable) {
             // If the URL cannot be generated, we return the path as is
             return $data->path;

--- a/src/Normalizer/UrlNormalizer.php
+++ b/src/Normalizer/UrlNormalizer.php
@@ -43,7 +43,7 @@ final class UrlNormalizer implements NormalizerInterface, NormalizerAwareInterfa
         try {
             $params = [
                 '_locale' => $context['translatable_normalization_locale'] ?? null,
-                ...$data->params
+                ...$data->params,
             ];
 
             return $this->router->generate($data->path, $params, $data->pathTypeReference);


### PR DESCRIPTION
Target branch: 1.3.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

This update ensures that the locale is included in the parameters when generating URLs, leveraging the normalization context. If no locale is provided, the default behavior remains unchanged. This improves localization support for URL normalization.
