### PR TITLE
Refactor shortcuts normalization to handle icon expansion

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1717,10 +1717,16 @@ parameters:
 			path: src/Resources/config/definition/utils/icons.php
 
 		-
+			message: '#^Parameter \#1 \$icons of function expandIcons expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Resources/config/definition/utils/shortcuts.php
+
+		-
 			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Resources/config/definition/utils/icons.php
+			path: src/Resources/config/definition/utils/shortcuts.php
 
 		-
 			message: '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition\:\:children\(\)\.$#'

--- a/src/Resources/config/definition/utils/icons.php
+++ b/src/Resources/config/definition/utils/icons.php
@@ -9,6 +9,11 @@ function expandIcons(array $icons): array
 {
     $expandedIcons = [];
     foreach ($icons as $icon) {
+        if (! is_array($icon)) {
+            $icon = [
+                'src' => $icon,
+            ];
+        }
         if (! array_key_exists('sizes', $icon) || ! is_array($icon['sizes'])) {
             $expandedIcons[] = $icon;
             continue;

--- a/src/Resources/config/definition/utils/shortcuts.php
+++ b/src/Resources/config/definition/utils/shortcuts.php
@@ -16,6 +16,13 @@ function setupShortcuts(): ArrayNodeDefinition
         ->treatNullLike([])
         ->info('The shortcuts of the application.')
         ->arrayPrototype()
+            ->beforeNormalization()
+                ->ifTrue(static fn (mixed $v): bool => array_key_exists('icons', $v) && is_array($v['icons']))
+                ->then(static function (array $v): array {
+                    $v['icons'] = expandIcons($v['icons'] ?? []);
+                    return $v;
+                })
+            ->end()
             ->children()
                 ->scalarNode('name')
                     ->isRequired()


### PR DESCRIPTION
Target branch: 1.3
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
Add a normalization step to detect and expand the 'icons' array in the shortcuts configuration. This ensures that any provided 'icons' are processed consistently before further handling.
