### PR TITLE
Add Wake Lock Controller for managing screen wake locks.

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -151,6 +151,13 @@
                 "webpackMode": "eager",
                 "fetch": "eager",
                 "enabled": true
+            },
+            "wake-lock": {
+                "main": "src/wake-lock_controller.js",
+                "name": "pwa/wake-lock",
+                "webpackMode": "eager",
+                "fetch": "eager",
+                "enabled": true
             }
         },
         "importmap": {

--- a/assets/src/wake-lock_controller.js
+++ b/assets/src/wake-lock_controller.js
@@ -1,0 +1,41 @@
+'use strict';
+
+import AbstractController from './abstract_controller.js';
+
+/* stimulusFetch: 'lazy' */
+export default class extends AbstractController {
+    static values = {
+        lockOnVisible: { type: Boolean, default: false },
+    };
+    wakeLock = null;
+
+    async connect() {
+        if (this.lockOnVisibleValue === true) {
+            this.lock();
+            document.addEventListener('visibilitychange', this._handleVisibilityChange);
+        }
+    }
+
+    async lock() {
+        this.wakeLock = await navigator.wakeLock.request('screen');
+        this.wakeLock.addEventListener('release', () => {
+            this.dispatchEvent('pwa:wake-lock:released');
+            this.wakeLock = null;
+        });
+        this.dispatchEvent('pwa:wake-lock:active', {wakeLock: this.wakeLock});
+    }
+
+    async release() {
+        if (this.wakeLock) {
+            this.wakeLock.release();
+        }
+    }
+
+    _handleVisibilityChange = async () => {
+        if (document.visibilityState === 'visible') {
+            setTimeout(async () => {
+                await this.lock();
+            }, 1000);
+        }
+    };
+}


### PR DESCRIPTION
Target branch: 1.3
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
Introduces a stimulus controller to handle wake locks, ensuring the screen remains awake based on visibility. Configurations are added to `package.json` to enable proper import and usage. This feature supports enhanced functionality for PWAs.
