### PR TITLE
Add contact controller and integrate with package.json

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -33,6 +33,13 @@
                 "fetch": "eager",
                 "enabled": true
             },
+            "contact": {
+                "main": "src/contact_controller.js",
+                "name": "pwa/contact",
+                "webpackMode": "eager",
+                "fetch": "eager",
+                "enabled": true
+            },
             "device-motion": {
                 "main": "src/device-motion_controller.js",
                 "name": "pwa/device-motion",

--- a/assets/src/contact_controller.js
+++ b/assets/src/contact_controller.js
@@ -1,0 +1,29 @@
+'use strict';
+
+import AbstractController from './abstract_controller.js';
+
+/* stimulusFetch: 'lazy' */
+export default class extends AbstractController {
+    connect = async () => {
+        if (!this._isSupported()) {
+            this.dispatchEvent('unavailable');
+        }
+    }
+
+    select = async (multiple = false) => {
+        if (!this._isSupported()) {
+            this.dispatchEvent('unavailable');
+            return;
+        }
+        try {
+            const contacts = await navigator.contacts.select(await navigator.contacts.getProperties(), {multiple});
+            this.dispatchEvent('selection', { contacts });
+        } catch (exception) {
+            this.dispatchEvent('error', { exception });
+        }
+    }
+
+    _isSupported = () => {
+        return "contacts" in navigator;
+    }
+}


### PR DESCRIPTION
Target branch: 1.3.x
Resolves issue #

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Introduce a new `contact` controller to manage contact selection using the Contacts API. Updated `package.json` to include the new controller with eager fetching enabled. The controller ensures support detection and handles events for contact selection, errors, and unavailability.
