### PR TITLE
Refactor install event handling with prioritized tasks

### DIFF
--- a/src/CachingStrategy/WorkboxCacheStrategy.php
+++ b/src/CachingStrategy/WorkboxCacheStrategy.php
@@ -178,9 +178,7 @@ ROUTE_REGISTRATION;
         if ($this->preloadUrls !== []) {
             $urls = json_encode($this->preloadUrls, $jsonOptions);
             $declaration .= <<<ASSET_CACHE_RULE_PRELOAD
-self.addEventListener('install', event => {
-  event.waitUntil(precacheResources({$cacheObjectName}, {$urls}, event));
-});
+registerInstallTask((event) => precacheResources({$cacheObjectName}, {$urls}, event));
 
 ASSET_CACHE_RULE_PRELOAD;
         }

--- a/src/ServiceWorkerRule/ClearCache.php
+++ b/src/ServiceWorkerRule/ClearCache.php
@@ -48,16 +48,9 @@ DEBUG_COMMENT;
         }
 
         $declaration .= <<<CLEAR_CACHE
-self.addEventListener("install", function (event) {
-    event.waitUntil(caches.keys().then(function (cacheNames) {
-            return Promise.all(
-                cacheNames.map(function (cacheName) {
-                    return caches.delete(cacheName);
-                })
-            );
-        })
-    );
-});
+registerInstallTask(() =>
+  caches.keys().then(keys => Promise.all(keys.map(k => caches.delete(k))))
+, 0);
 
 CLEAR_CACHE;
 

--- a/src/ServiceWorkerRule/SkipWaiting.php
+++ b/src/ServiceWorkerRule/SkipWaiting.php
@@ -38,9 +38,7 @@ DEBUG_COMMENT;
         }
 
         $declaration .= <<<SKIP_WAITING
-self.addEventListener("install", function (event) {
-  event.waitUntil(self.skipWaiting());
-});
+registerInstallTask(() => self.skipWaiting(), 5);
 self.addEventListener("activate", function (event) {
   event.waitUntil(self.clients.claim());
 });

--- a/src/ServiceWorkerRule/WorkboxHelpers.php
+++ b/src/ServiceWorkerRule/WorkboxHelpers.php
@@ -29,13 +29,15 @@ function registerCacheFirst(routeMatchFn, cacheName, plugins = []) {
 }
 
 function precacheResources(strategy, resourceList, event) {
-  const preload = resourceList.map(path =>
+  if (!(event instanceof ExtendableEvent)) {
+    throw new Error("precacheResources needs a valid ExtendableEvent");
+  }
+  return Promise.all(resourceList.map(path =>
     strategy.handleAll({
       event,
       request: new Request(path),
     })[1]
-  );
-  return Promise.all(preload);
+  ));
 }
 
 function createBackgroundSyncPlugin(queueName, maxRetentionTime = 2880, forceSyncFallback = false) {
@@ -116,6 +118,38 @@ function createBackgroundSyncPluginWithBroadcast(queueName, channelName, maxRete
   };
 }
 
+const installTasks = [];
+function registerInstallTask(callback, priority = 100) {
+  installTasks.push({
+    callback: (event) => {
+      const result = callback(event);
+      if (!result?.then) console.warn("Install task did not return a Promise");
+      return result;
+    },
+    priority,
+  });
+}
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    installTasks
+      .sort((a, b) => a.priority - b.priority)
+      .reduce(
+        (chain, task) => chain.then(() => task.callback(event)),
+        Promise.resolve()
+      )
+  );
+});
+
+function statusGuard(min, max) {
+  return {
+    fetchDidSucceed: ({ response }) => {
+      if (response.status >= min && response.status <= max) {
+        throw new Error(`Server error: \${response.status}`);
+      }
+      return response;
+    }
+  };
+}
 CUSTOM_HELPERS;
     }
 

--- a/src/WorkboxPlugin/ExpectErrorOnRangePlugin.php
+++ b/src/WorkboxPlugin/ExpectErrorOnRangePlugin.php
@@ -14,7 +14,7 @@ final readonly class ExpectErrorOnRangePlugin implements CachePluginInterface
 
     public function render(int $jsonOptions = 0): string
     {
-        return "{fetchDidSucceed: ({response}) => {if (response.status >= {$this->minCode} && response.status <= {$this->maxCode}) {throw new Error('Server error.');}return response;}}";
+        return "statusGuard({$this->minCode}, {$this->maxCode})";
     }
 
     public static function create(int $minCode, int $maxCode): self


### PR DESCRIPTION
Target branch: 1.3.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Introduces `registerInstallTask` for streamlined and prioritized handling of install event tasks across service worker rules. Replaces repetitive `self.addEventListener('install')` logic with this new abstraction, enhancing maintainability and readability. Additionally, minor improvements include validation in `precacheResources` and reuse of `statusGuard` for response validation.
