### PR TITLE
Add message listener to support skipWaiting in service worker

### DIFF
--- a/src/ServiceWorkerRule/WorkboxHelpers.php
+++ b/src/ServiceWorkerRule/WorkboxHelpers.php
@@ -150,6 +150,11 @@ function statusGuard(min, max) {
     }
   };
 }
+self.addEventListener('message', (event) => {
+  if (event.data?.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
 CUSTOM_HELPERS;
     }
 

--- a/src/Twig/PwaRuntime.php
+++ b/src/Twig/PwaRuntime.php
@@ -129,10 +129,29 @@ final readonly class PwaRuntime
             $declaration = <<<SERVICE_WORKER
 <script type="module"{$scriptAttributes}>
   import {Workbox} from '{$workboxUrl}';
+
   if ('serviceWorker' in navigator) {
     const wb = new Workbox('{$url}'{$registerOptions});
-    wb.register();
-    window.workbox = wb;
+
+    wb.addEventListener('waiting', () => {
+      const event = new CustomEvent('sw:update-available', { detail: { wb } });
+      window.dispatchEvent(event);
+    });
+
+    let refreshing = false;
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      if (!refreshing) {
+        window.location.reload();
+        refreshing = true;
+      }
+    });
+
+    try {
+      await wb.register();
+      window.workbox = wb;
+    } catch (e) {
+      console.error('SW registration failed', e);
+    }
   }
 </script>
 SERVICE_WORKER;


### PR DESCRIPTION
Target branch: 1.3.x
Resolves issue #309 

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

This ensures the service worker can skip the waiting phase when instructed via a 'SKIP_WAITING' message. It improves the update workflow by enabling immediate activation of the new service worker.

Introduce event handling for service worker updates, enabling users to respond to updates via a custom event. Additionally, add error handling for service worker registration and ensure a page refresh occurs on `controllerchange` to apply updates seamlessly.