### PR TITLE
Selective cache purge

### DIFF
--- a/src/CachingStrategy/WorkboxCacheStrategy.php
+++ b/src/CachingStrategy/WorkboxCacheStrategy.php
@@ -122,7 +122,7 @@ final class WorkboxCacheStrategy implements CacheStrategyInterface
         }
         $cacheName = '';
         if ($this->strategy !== self::STRATEGY_NETWORK_ONLY) {
-            $cacheName = sprintf("cacheName: '%s',", $this->getName() ?? $cacheObjectName);
+            $cacheName = sprintf("cacheName: registerCacheName('%s'),", $this->getName() ?? $cacheObjectName);
         }
 
         $plugins = [];

--- a/src/ServiceWorkerRule/ClearCache.php
+++ b/src/ServiceWorkerRule/ClearCache.php
@@ -49,7 +49,13 @@ DEBUG_COMMENT;
 
         $declaration .= <<<CLEAR_CACHE
 registerInstallTask(() =>
-  caches.keys().then(keys => Promise.all(keys.map(k => caches.delete(k))))
+  caches.keys().then(keys =>
+    Promise.all(
+      keys
+        .filter(k => usedCacheNames.has(k))
+        .map(k => caches.delete(k))
+    )
+  )
 , 0);
 
 CLEAR_CACHE;

--- a/src/ServiceWorkerRule/OfflineFallback.php
+++ b/src/ServiceWorkerRule/OfflineFallback.php
@@ -74,7 +74,7 @@ DEBUG_COMMENT;
         $declaration .= <<<OFFLINE_FALLBACK_STRATEGY
 workbox.routing.setDefaultHandler(new workbox.strategies.NetworkOnly());
 registerInstallTask(() => {
-  return caches.open('{$cacheName}').then(cache =>
+  return caches.open(registerCacheName('{$cacheName}')).then(cache =>
     cache.addAll({$urls})
   );
 }, 10);

--- a/src/ServiceWorkerRule/WorkboxHelpers.php
+++ b/src/ServiceWorkerRule/WorkboxHelpers.php
@@ -150,11 +150,18 @@ function statusGuard(min, max) {
     }
   };
 }
+
 self.addEventListener('message', (event) => {
   if (event.data?.type === 'SKIP_WAITING') {
     self.skipWaiting();
   }
 });
+
+const usedCacheNames = new Set();
+function registerCacheName(name) {
+  usedCacheNames.add(name);
+  return name;
+}
 CUSTOM_HELPERS;
     }
 


### PR DESCRIPTION
Target branch: 1.3.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Introduced a `registerCacheName` function to track used cache names, replacing direct cache name assignments. Updated caching and cleanup logic to ensure only registered caches are deleted, improving control and preventing unintended cache removals.