### PR TITLE
better error message with invalid source path

### DIFF
--- a/src/Service/IconResolver.php
+++ b/src/Service/IconResolver.php
@@ -140,9 +140,10 @@ final readonly class IconResolver
                 false,
             );
         }
-        $asset = $this->assetMapper->getAsset($asset->src);
-        assert($asset instanceof MappedAsset, sprintf('Invalid asset "%s"', $asset->sourcePath));
+        $mappedAsset = $this->assetMapper->getAsset($asset->src);
+        assert($mappedAsset, sprintf('Invalid asset "%s"', $asset->src));
+        assert($mappedAsset instanceof MappedAsset, sprintf('Invalid asset "%s"', $mappedAsset->sourcePath));
 
-        return $asset;
+        return $mappedAsset;
     }
 }


### PR DESCRIPTION
If the icon src path is invalid, the error message doesn't tell the developer which path is invalid.  This PR checks for a valid source file and displays an error with the path if it's invalid.

<!-- replace space with "x" in square brackets: [x] -->
- [ X ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

To me this is more a bug fix