### PR TITLE
Fix infection tests

### DIFF
--- a/.ci-tools/infection.json.dist
+++ b/.ci-tools/infection.json.dist
@@ -1,19 +1,28 @@
 {
-    "source": {
-        "directories": [
-            "src"
-        ]
+  "source": {
+    "directories": ["src"],
+    "excludes": [
+      "src/Kernel.php",
+      "src/DependencyInjection",
+      "src/Event",
+      "src/Twig"
+    ]
+  },
+  "logs": {
+    "text": "infection.log"
+  },
+  "mutators": {
+    "@default": true,
+
+    "MBString": {
+      "settings": {
+        "mb_substr": false,
+        "mb_strlen": false
+      }
     },
-    "logs": {
-        "text": "infection.log"
-    },
-    "mutators": {
-        "@default": true,
-        "MBString": {
-            "settings": {
-                "mb_substr": false,
-                "mb_strlen": false
-            }
-        }
-    }
+
+    "PublicVisibility": false,
+    "For_": false
+  },
+  "timeout": 10
 }

--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -928,6 +928,12 @@ parameters:
 			path: ../src/Event/PreManifestCompileEvent.php
 
 		-
+			message: '#^Constructor in SpomkyLabs\\PwaBundle\\EventListener\\FileCompileEventListener has parameter \$enabled with default value\.$#'
+			identifier: ergebnis.noConstructorParameterWithDefaultValue
+			count: 1
+			path: ../src/EventListener/FileCompileEventListener.php
+
+		-
 			message: '#^Method SpomkyLabs\\PwaBundle\\EventListener\\PwaDevServerListener\:\:__construct\(\) has parameter \$profiler with a nullable type declaration\.$#'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
 			count: 1

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -8,23 +8,24 @@ on:
 jobs:
   mutation_testing:
     name: "0️⃣ Mutation Testing"
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/spomky-labs/phpqa:8.4
+    env:
+      XDEBUG_MODE: coverage
     steps:
-      - name: "Set up PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "8.3"
-          extensions: "json, mbstring, sockets, gd, curl, imagick"
-          tools: castor
+      - uses: actions/checkout@v4
 
-      - name: "Checkout code"
-        uses: "actions/checkout@v4"
-
-      - name: "Install dependencies"
-        uses: "ramsey/composer-install@v3"
+      - uses: ramsey/composer-install@v3
         with:
-          dependency-versions: "highest"
-          composer-options: "--optimize-autoloader"
+          dependency-versions: highest
+          composer-options: --optimize-autoloader
+
+      - name: Restore PHPUnit result cache
+        uses: actions/cache@v4
+        with:
+          path: .phpunit.cache
+          key: phpunit-cache-${{ hashFiles('composer.lock') }}
 
       - name: "Execute Infection"
-        run: "castor infect"
+        run: infection --min-msi=35 --min-covered-msi=80 --threads=max --logger-github -s --configuration=.ci-tools/infection.json.dist

--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
         "phpstan": "docker run --init -it --rm --user \"$(id -u):$(id -g)\" --pull always -v \"$PWD\":/project -v \"$PWD/tmp-phpqa:/tmp\" -w /project ghcr.io/spomky-labs/phpqa:8.4 phpstan analyse --configuration=.ci-tools/phpstan.neon",
         "phpstan:baseline": "docker run --init -it --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -v \"$PWD/tmp-phpqa:/tmp\" -w /project ghcr.io/spomky-labs/phpqa:8.4 phpstan analyse --configuration=.ci-tools/phpstan.neon --generate-baseline=.ci-tools/phpstan-baseline.neon",
         "deptrac": "docker run --init -it --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -v \"$PWD/tmp-phpqa:/tmp\" -w /project ghcr.io/spomky-labs/phpqa:8.4 deptrac --config-file .ci-tools/deptrac.yaml --report-uncovered --report-skipped --fail-on-uncovered",
-        "lint": "docker run --init -it --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -v \"$PWD/tmp-phpqa:/tmp\" -w /project ghcr.io/spomky-labs/phpqa:8.4 composer exec -- parallel-lint src tests"
+        "lint": "docker run --init -it --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -v \"$PWD/tmp-phpqa:/tmp\" -w /project ghcr.io/spomky-labs/phpqa:8.4 composer exec -- parallel-lint src tests",
+        "infect": "docker run --init -it --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -v \"$PWD/tmp-phpqa:/tmp\" -w /project -e XDEBUG_MODE=coverage ghcr.io/spomky-labs/phpqa:8.4 infection --min-msi=35 --min-covered-msi=80 --threads=max --logger-github -s --filter=src/ --configuration=.ci-tools/infection.json.dist"
     }
 }

--- a/src/EventListener/FileCompileEventListener.php
+++ b/src/EventListener/FileCompileEventListener.php
@@ -14,7 +14,7 @@ final readonly class FileCompileEventListener
     public function __construct(
         private FileCompiler $fileCompiler,
         #[Autowire(param: 'spomky_labs_pwa.asset_compiler')]
-        private bool $enabled,
+        private bool $enabled = true,
     ) {
     }
 


### PR DESCRIPTION


Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Make asset compilation enabled by default in `FileCompileEventListene…r`. Update CI configurations for improved caching and introduce mutation testing setup with adjusted `.ci-tools/infection.json.dist`. Update phpstan baseline.
