### PR TITLE
Update PHPUnit and Infection configurations for enhanced coverage

### DIFF
--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -28,4 +28,4 @@ jobs:
           key: phpunit-cache-${{ hashFiles('composer.lock') }}
 
       - name: "Execute Infection"
-        run: infection --min-msi=35 --min-covered-msi=80 --threads=max --logger-github -s --configuration=.ci-tools/infection.json.dist
+        run: infection --coverage=coverage --min-msi=35 --min-covered-msi=80 --threads=max --logger-github -s --filter=src/ --configuration=.ci-tools/infection.json.dist

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -153,7 +153,7 @@ jobs:
           composer-options: --optimize-autoloader
 
       - name: Run PHPUnit
-        run: phpunit --coverage-text --configuration .ci-tools/phpunit.xml.dist
+        run: phpunit --coverage-xml .ci-tools/coverage  --log-junit=.ci-tools/coverage/junit.xml --configuration .ci-tools/phpunit.xml.dist
 
   exported_files:
     name: "9️⃣ Exported files"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ package-lock.json
 /public
 /.castor.stub.php
 /tmp*
+/.ci-tools/coverage

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "symfony/panther": "For generating screenshots directly from your application"
     },
     "scripts": {
-        "phpunit": "docker run --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -w /project ghcr.io/spomky-labs/phpqa:8.4 phpunit --configuration .ci-tools/phpunit.xml.dist",
+        "phpunit": "docker run --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -w /project -e XDEBUG_MODE=coverage ghcr.io/spomky-labs/phpqa:8.4 phpunit --coverage-xml .ci-tools/coverage  --log-junit=.ci-tools/coverage/junit.xml --configuration .ci-tools/phpunit.xml.dist",
         "ecs": "docker run --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -w /project ghcr.io/spomky-labs/phpqa:8.4 ecs check --config .ci-tools/ecs.php",
         "ecs:fix": "docker run --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -w /project ghcr.io/spomky-labs/phpqa:8.4 ecs check --config .ci-tools/ecs.php --fix",
         "rector": "docker run --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -w /project ghcr.io/spomky-labs/phpqa:8.4 rector process --dry-run --config .ci-tools/rector.php",
@@ -86,6 +86,6 @@
         "phpstan:baseline": "docker run --init -it --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -v \"$PWD/tmp-phpqa:/tmp\" -w /project ghcr.io/spomky-labs/phpqa:8.4 phpstan analyse --configuration=.ci-tools/phpstan.neon --generate-baseline=.ci-tools/phpstan-baseline.neon",
         "deptrac": "docker run --init -it --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -v \"$PWD/tmp-phpqa:/tmp\" -w /project ghcr.io/spomky-labs/phpqa:8.4 deptrac --config-file .ci-tools/deptrac.yaml --report-uncovered --report-skipped --fail-on-uncovered",
         "lint": "docker run --init -it --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -v \"$PWD/tmp-phpqa:/tmp\" -w /project ghcr.io/spomky-labs/phpqa:8.4 composer exec -- parallel-lint src tests",
-        "infect": "docker run --init -it --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -v \"$PWD/tmp-phpqa:/tmp\" -w /project -e XDEBUG_MODE=coverage ghcr.io/spomky-labs/phpqa:8.4 infection --min-msi=35 --min-covered-msi=80 --threads=max --logger-github -s --filter=src/ --configuration=.ci-tools/infection.json.dist"
+        "infect": "docker run --init -it --rm --user \"$(id -u):$(id -u)\" --pull always -v \"$PWD\":/project -v \"$PWD/tmp-phpqa:/tmp\" -w /project -e XDEBUG_MODE=coverage ghcr.io/spomky-labs/phpqa:8.4 infection --coverage=coverage --min-msi=35 --min-covered-msi=80 --threads=max --logger-github -s --filter=src/ --configuration=.ci-tools/infection.json.dist"
     }
 }


### PR DESCRIPTION
Target branch: 1.3
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Update PHPUnit and Infection configurations for enhanced coverage reporting

- Adjust `.gitignore` to include `.ci-tools/coverage`.
- Update PHPUnit commands to generate XML coverage and JUnit reports.
- Modify Infection commands to utilize generated coverage files.
- Update CI workflows to reflect these changes.