### PR TITLE
Add 'type' property to ScopeExtension and update static analysis configuration

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -625,6 +625,12 @@ parameters:
 			path: ../src/Dto/ScopeExtension.php
 
 		-
+			message: '#^Class SpomkyLabs\\PwaBundle\\Dto\\ScopeExtension has an uninitialized property \$type\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: ../src/Dto/ScopeExtension.php
+
+		-
 			message: '#^Class SpomkyLabs\\PwaBundle\\Dto\\Screenshot has an uninitialized property \$src\. Give it default value or assign it in the constructor\.$#'
 			identifier: property.uninitialized
 			count: 1
@@ -1836,19 +1842,19 @@ parameters:
 		-
 			message: '#^Cannot call method defaultValue\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 3
 			path: ../src/Resources/config/definition/manifest.php
 
 		-
 			message: '#^Cannot call method end\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 33
+			count: 34
 			path: ../src/Resources/config/definition/manifest.php
 
 		-
 			message: '#^Cannot call method example\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 17
+			count: 18
 			path: ../src/Resources/config/definition/manifest.php
 
 		-
@@ -1860,7 +1866,7 @@ parameters:
 		-
 			message: '#^Cannot call method info\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 24
+			count: 25
 			path: ../src/Resources/config/definition/manifest.php
 
 		-
@@ -1878,7 +1884,7 @@ parameters:
 		-
 			message: '#^Cannot call method scalarNode\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 16
+			count: 17
 			path: ../src/Resources/config/definition/manifest.php
 
 		-

--- a/castor.php
+++ b/castor.php
@@ -342,7 +342,7 @@ function prepare_pr(): void
 
     io()
         ->section('Running static analysis…');
-    phpstan();
+    phpstan_baseline();
     deptrac();
     lint();
 

--- a/src/Dto/ScopeExtension.php
+++ b/src/Dto/ScopeExtension.php
@@ -6,5 +6,7 @@ namespace SpomkyLabs\PwaBundle\Dto;
 
 final class ScopeExtension
 {
+    public string $type;
+
     public string $origin;
 }

--- a/src/Resources/config/definition/manifest.php
+++ b/src/Resources/config/definition/manifest.php
@@ -122,6 +122,13 @@ return static function (DefinitionConfigurator $definition): void {
         )
         ->arrayPrototype()
         ->children()
+        ->scalarNode('type')
+        ->defaultValue('origin')
+        ->info(
+            'Specifies the type of scope extension. This is currently always origin (default), but future extensions may add other types.'
+        )
+        ->example(['origin'])
+        ->end()
         ->scalarNode('origin')
         ->isRequired()
         ->info('Specifies the origin pattern to associate with.')


### PR DESCRIPTION
Target branch: 1.3.x
Resolves issue #333 

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations
