### PR TITLE
Refactor favicon asset retrieval to use file_get_contents instead of Filesystem

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -2650,6 +2650,12 @@ parameters:
 			path: ../src/Service/FaviconsCompiler.php
 
 		-
+			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\FaviconsCompiler::getFaviconAsset() should return string but returns string|false.'
+			identifier: return.type
+			count: 2
+			path: ../src/Service/FaviconsCompiler.php
+
+		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\FaviconsCompiler::processIcon() has parameter $media with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
 			count: 1
@@ -2746,7 +2752,19 @@ parameters:
 			path: ../src/Service/IconResolver.php
 
 		-
+			rawMessage: 'Parameter #1 $image of method SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface::process() expects string, string|false given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/Service/IconResolver.php
+
+		-
 			rawMessage: 'Parameter #2 $attributes of method Symfony\UX\Icons\IconRendererInterface::renderIcon() expects array<string, bool|string>, array<string, mixed> given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/Service/IconResolver.php
+
+		-
+			rawMessage: 'Parameter #2 $data of function hash expects string, string|false given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Service/IconResolver.php
@@ -2755,6 +2773,12 @@ parameters:
 			rawMessage: 'Parameter #3 $headers of class SpomkyLabs\PwaBundle\Service\Data constructor expects array<string, bool|string>, array<string, string|true|null> given.'
 			identifier: argument.type
 			count: 2
+			path: ../src/Service/IconResolver.php
+
+		-
+			rawMessage: 'Parameter #5 $content of class Symfony\Component\AssetMapper\MappedAsset constructor expects string|null, string|false given.'
+			identifier: argument.type
+			count: 1
 			path: ../src/Service/IconResolver.php
 
 		-

--- a/src/Service/FaviconsCompiler.php
+++ b/src/Service/FaviconsCompiler.php
@@ -14,7 +14,6 @@ use SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\AssetMapper\MappedAsset;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 use Symfony\UX\Icons\IconRendererInterface;
@@ -408,7 +407,7 @@ XML;
     private function getFaviconAsset(Asset $asset, array $attributes): string
     {
         if (str_starts_with($asset->src, '/')) {
-            return (new Filesystem())->readFile($asset->src);
+            return file_get_contents($asset->src);
         }
         if ($this->renderer !== null && str_contains($asset->src, ':')) {
             return $this->renderer->renderIcon($asset->src, $attributes);
@@ -419,7 +418,7 @@ XML;
 
         $content = $mappedAsset->content;
         if ($content === null) {
-            $content = (new Filesystem())->readFile($mappedAsset->sourcePath);
+            $content = file_get_contents($mappedAsset->sourcePath);
         }
 
         return $content;

--- a/src/Service/IconResolver.php
+++ b/src/Service/IconResolver.php
@@ -12,7 +12,6 @@ use SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\AssetMapper\MappedAsset;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Mime\MimeTypes;
 use Symfony\UX\Icons\IconRendererInterface;
 use function array_key_exists;
@@ -42,7 +41,7 @@ final readonly class IconResolver
         $asset = $this->getAsset($icon->src, $icon->svgAttributes);
         $content = $asset->content;
         if ($content === null) {
-            $content = (new Filesystem())->readFile($asset->sourcePath);
+            $content = file_get_contents($asset->sourcePath);
         }
 
         $imageProcessor = fn (Configuration $configuration): string => $this->imageProcessor->process(
@@ -134,7 +133,7 @@ final readonly class IconResolver
     private function getAsset(Asset $asset, array $attributes): MappedAsset
     {
         if (str_starts_with($asset->src, '/')) {
-            $content = (new Filesystem())->readFile($asset->src);
+            $content = file_get_contents($asset->src);
             $hash = hash('xxh128', $content);
             $fileinfo = pathinfo($asset->src);
             assert(is_array($fileinfo), 'Invalid file.');


### PR DESCRIPTION
Target branch: 1.3.x
Resolves issue #359 

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
