### PR TITLE
Add #[Screenshot] attribute with automatic manifest integration

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -1,18 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\Attribute\PreloadUrl has parameter $params with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/Attribute/PreloadUrl.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\Attribute\PreloadUrl has parameter $pathTypeReference with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/Attribute/PreloadUrl.php
-
-		-
 			rawMessage: 'Only iterables can be unpacked, mixed given in argument #1.'
 			identifier: argument.unpackNonIterable
 			count: 1
@@ -35,12 +23,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../src/CachingStrategy/AssetCache.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\CachingStrategy\CacheStrategyInterface::getName() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/CachingStrategy/CacheStrategyInterface.php
 
 		-
 			rawMessage: 'Only iterables can be unpacked, mixed given in argument #1.'
@@ -85,26 +67,14 @@ parameters:
 			path: ../src/CachingStrategy/ResourceCaches.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\CachingStrategy\WorkboxCacheStrategy::getMethod() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/CachingStrategy/WorkboxCacheStrategy.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\CachingStrategy\WorkboxCacheStrategy::getName() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/CachingStrategy/WorkboxCacheStrategy.php
-
-		-
 			rawMessage: 'Part $this->options[''networkTimeoutSeconds''] (mixed) of encapsed string cannot be cast to string.'
 			identifier: encapsedStringPart.nonString
 			count: 1
 			path: ../src/CachingStrategy/WorkboxCacheStrategy.php
 
 		-
-			rawMessage: Class "SpomkyLabs\PwaBundle\Command\CompileCommand" is not allowed to extend "Symfony\Component\Console\Command\Command".
-			identifier: ergebnis.noExtends
+			rawMessage: 'Only booleans are allowed in &&, bool|null given on the right side.'
+			identifier: booleanAnd.rightNotBoolean
 			count: 1
 			path: ../src/Command/CompileCommand.php
 
@@ -123,18 +93,6 @@ parameters:
 		-
 			rawMessage: Cannot cast mixed to string.
 			identifier: cast.string
-			count: 1
-			path: ../src/Command/CreateIconsCommand.php
-
-		-
-			rawMessage: Class "SpomkyLabs\PwaBundle\Command\CreateIconsCommand" is not allowed to extend "Symfony\Component\Console\Command\Command".
-			identifier: ergebnis.noExtends
-			count: 1
-			path: ../src/Command/CreateIconsCommand.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Command\CreateIconsCommand::__construct() has parameter $imageProcessor with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
 			count: 1
 			path: ../src/Command/CreateIconsCommand.php
 
@@ -163,60 +121,6 @@ parameters:
 			path: ../src/Command/CreateIconsCommand.php
 
 		-
-			rawMessage: 'Call to method manage() on an unknown class Symfony\Component\Panther\Client.'
-			identifier: class.notFound
-			count: 2
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Call to method request() on an unknown class Symfony\Component\Panther\Client.'
-			identifier: class.notFound
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Call to method takeScreenshot() on an unknown class Symfony\Component\Panther\Client.'
-			identifier: class.notFound
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Call to method waitFor() on an unknown class Symfony\Component\Panther\Client.'
-			identifier: class.notFound
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Call to static method createChromeClient() on an unknown class Symfony\Component\Panther\Client.'
-			identifier: class.notFound
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Cannot call method fullscreen() on mixed.'
-			identifier: method.nonObject
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Cannot call method html() on mixed.'
-			identifier: method.nonObject
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Cannot call method setSize() on mixed.'
-			identifier: method.nonObject
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Cannot call method window() on mixed.'
-			identifier: method.nonObject
-			count: 2
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
 			rawMessage: Cannot cast mixed to int.
 			identifier: cast.int
 			count: 2
@@ -225,67 +129,7 @@ parameters:
 		-
 			rawMessage: Cannot cast mixed to string.
 			identifier: cast.string
-			count: 3
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: Class "SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand" is not allowed to extend "Symfony\Component\Console\Command\Command".
-			identifier: ergebnis.noExtends
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: Cloning object of an unknown class Symfony\Component\Panther\Client.
-			identifier: class.notFound
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand has parameter $userAgent with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand has parameter $webClient with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: Instantiated class Facebook\WebDriver\WebDriverDimension not found.
-			identifier: class.notFound
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand::__construct() has parameter $imageProcessor with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand::__construct() has parameter $userAgent with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand::__construct() has parameter $userAgent with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand::__construct() has parameter $webClient with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand::__construct() has parameter $webClient with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
+			count: 2
 			path: ../src/Command/CreateScreenshotCommand.php
 
 		-
@@ -295,32 +139,8 @@ parameters:
 			path: ../src/Command/CreateScreenshotCommand.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand::getClient() has invalid return type Symfony\Component\Panther\Client.'
-			identifier: class.notFound
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand::getClient() should return Symfony\Component\Panther\Client but returns mixed.'
-			identifier: return.type
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand::getDefaultArguments() return type has no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Method Symfony\Component\Panther\Client::createChromeClient() is invoked with named argument for parameter $arguments.'
-			identifier: ergebnis.noNamedArgument
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: 'Method Symfony\Component\Panther\Client::createChromeClient() is invoked with named argument for parameter $options.'
-			identifier: ergebnis.noNamedArgument
 			count: 1
 			path: ../src/Command/CreateScreenshotCommand.php
 
@@ -337,50 +157,26 @@ parameters:
 			path: ../src/Command/CreateScreenshotCommand.php
 
 		-
+			rawMessage: 'Parameter #2 $uri of method Symfony\Component\Panther\Client::request() expects string, mixed given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/Command/CreateScreenshotCommand.php
+
+		-
 			rawMessage: 'Parameter #3 ...$values of function sprintf expects bool|float|int|string|null, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Command/CreateScreenshotCommand.php
 
 		-
-			rawMessage: 'Parameter $webClient of method SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand::__construct() has invalid type Symfony\Component\Panther\Client.'
-			identifier: class.notFound
+			rawMessage: 'Parameter $arguments of static method Symfony\Component\Panther\Client::createChromeClient() expects array<string>|null, array given.'
+			identifier: argument.type
 			count: 1
 			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: Property SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand::$webClient has unknown class Symfony\Component\Panther\Client as its type.
-			identifier: class.notFound
-			count: 1
-			path: ../src/Command/CreateScreenshotCommand.php
-
-		-
-			rawMessage: Class "SpomkyLabs\PwaBundle\Command\ListCacheStrategiesCommand" is not allowed to extend "Symfony\Component\Console\Command\Command".
-			identifier: ergebnis.noExtends
-			count: 1
-			path: ../src/Command/ListCacheStrategiesCommand.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\CompilerPass\LoggerCompilerPass::process() has a parameter $container with a type declaration of Symfony\Component\DependencyInjection\ContainerBuilder, but containers should not be injected.'
-			identifier: ergebnis.noParameterWithContainerTypeDeclaration
-			count: 1
-			path: ../src/CompilerPass/LoggerCompilerPass.php
 
 		-
 			rawMessage: 'Generator expects value type array{alias: string, route: string, params: array<string, mixed>, pathTypeReference: int}, array{alias: string, route: mixed, params: array<string, mixed>, pathTypeReference: int} given.'
 			identifier: generator.valueType
-			count: 1
-			path: ../src/CompilerPass/PreloadUrlCompilerPass.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\CompilerPass\PreloadUrlCompilerPass::findAllTaggedRoutes() has a parameter $container with a type declaration of Symfony\Component\DependencyInjection\ContainerBuilder, but containers should not be injected.'
-			identifier: ergebnis.noParameterWithContainerTypeDeclaration
-			count: 1
-			path: ../src/CompilerPass/PreloadUrlCompilerPass.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\CompilerPass\PreloadUrlCompilerPass::process() has a parameter $container with a type declaration of Symfony\Component\DependencyInjection\ContainerBuilder, but containers should not be injected.'
-			identifier: ergebnis.noParameterWithContainerTypeDeclaration
 			count: 1
 			path: ../src/CompilerPass/PreloadUrlCompilerPass.php
 
@@ -403,26 +199,8 @@ parameters:
 			path: ../src/DataCollector/PwaCollector.php
 
 		-
-			rawMessage: Class "SpomkyLabs\PwaBundle\DataCollector\PwaCollector" is not allowed to extend "Symfony\Component\HttpKernel\DataCollector\DataCollector".
-			identifier: ergebnis.noExtends
-			count: 1
-			path: ../src/DataCollector/PwaCollector.php
-
-		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\DataCollector\PwaCollector::__construct() has parameter $locales with no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/DataCollector/PwaCollector.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\DataCollector\PwaCollector::collect() has parameter $exception with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/DataCollector/PwaCollector.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\DataCollector\PwaCollector::collect() has parameter $exception with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
 			count: 1
 			path: ../src/DataCollector/PwaCollector.php
 
@@ -493,18 +271,6 @@ parameters:
 			path: ../src/DataCollector/PwaCollector.php
 
 		-
-			rawMessage: Class "SpomkyLabs\PwaBundle\Dto\AssetCache" is not allowed to extend "SpomkyLabs\PwaBundle\Dto\Cache".
-			identifier: ergebnis.noExtends
-			count: 1
-			path: ../src/Dto/AssetCache.php
-
-		-
-			rawMessage: Class "SpomkyLabs\PwaBundle\Dto\BackgroundSync" is not allowed to extend "SpomkyLabs\PwaBundle\Dto\Cache".
-			identifier: ergebnis.noExtends
-			count: 1
-			path: ../src/Dto/BackgroundSync.php
-
-		-
 			rawMessage: Class SpomkyLabs\PwaBundle\Dto\BackgroundSync has an uninitialized property $forceSyncFallback. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
@@ -533,18 +299,6 @@ parameters:
 			identifier: property.uninitialized
 			count: 1
 			path: ../src/Dto/BackgroundSync.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Cache::maxAgeInSeconds() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Dto/Cache.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Cache::maxAgeInSeconds() is not final, but since the containing class is abstract, it should be.'
-			identifier: ergebnis.finalInAbstractClass
-			count: 1
-			path: ../src/Dto/Cache.php
 
 		-
 			rawMessage: Class SpomkyLabs\PwaBundle\Dto\Favicons has an uninitialized property $default. Give it default value or assign it in the constructor.
@@ -577,18 +331,6 @@ parameters:
 			path: ../src/Dto/FileHandler.php
 
 		-
-			rawMessage: Class "SpomkyLabs\PwaBundle\Dto\FontCache" is not allowed to extend "SpomkyLabs\PwaBundle\Dto\Cache".
-			identifier: ergebnis.noExtends
-			count: 1
-			path: ../src/Dto/FontCache.php
-
-		-
-			rawMessage: Class "SpomkyLabs\PwaBundle\Dto\GoogleFontCache" is not allowed to extend "SpomkyLabs\PwaBundle\Dto\Cache".
-			identifier: ergebnis.noExtends
-			count: 1
-			path: ../src/Dto/GoogleFontCache.php
-
-		-
 			rawMessage: Class SpomkyLabs\PwaBundle\Dto\GoogleFontCache has an uninitialized property $enabled. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
@@ -607,12 +349,6 @@ parameters:
 			path: ../src/Dto/Icon.php
 
 		-
-			rawMessage: Class "SpomkyLabs\PwaBundle\Dto\ImageCache" is not allowed to extend "SpomkyLabs\PwaBundle\Dto\Cache".
-			identifier: ergebnis.noExtends
-			count: 1
-			path: ../src/Dto/ImageCache.php
-
-		-
 			rawMessage: Property SpomkyLabs\PwaBundle\Dto\LaunchHandler::$clientMode type has no value type specified in iterable type array.
 			identifier: missingType.iterableValue
 			count: 1
@@ -625,20 +361,8 @@ parameters:
 			path: ../src/Dto/Manifest.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Manifest::getDescription() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Dto/Manifest.php
-
-		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Manifest::getDescription() should return string|Symfony\Contracts\Translation\TranslatableInterface|null but returns array<string|Symfony\Contracts\Translation\TranslatableInterface>|string|Symfony\Contracts\Translation\TranslatableInterface|null.'
 			identifier: return.type
-			count: 1
-			path: ../src/Dto/Manifest.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Manifest::getName() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
 			count: 1
 			path: ../src/Dto/Manifest.php
 
@@ -649,34 +373,10 @@ parameters:
 			path: ../src/Dto/Manifest.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Manifest::getShortName() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Dto/Manifest.php
-
-		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Manifest::getShortName() should return string|Symfony\Contracts\Translation\TranslatableInterface|null but returns array<string|Symfony\Contracts\Translation\TranslatableInterface>|string|Symfony\Contracts\Translation\TranslatableInterface|null.'
 			identifier: return.type
 			count: 1
 			path: ../src/Dto/Manifest.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Manifest::provideTranslation() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Dto/Manifest.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Manifest::provideTranslation() has parameter $data with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Dto/Manifest.php
-
-		-
-			rawMessage: Class "SpomkyLabs\PwaBundle\Dto\PageCache" is not allowed to extend "SpomkyLabs\PwaBundle\Dto\ResourceCache".
-			identifier: ergebnis.noExtends
-			count: 1
-			path: ../src/Dto/PageCache.php
 
 		-
 			rawMessage: Class SpomkyLabs\PwaBundle\Dto\PageCache extends @final class SpomkyLabs\PwaBundle\Dto\ResourceCache.
@@ -721,20 +421,8 @@ parameters:
 			path: ../src/Dto/RelatedApplication.php
 
 		-
-			rawMessage: Class "SpomkyLabs\PwaBundle\Dto\ResourceCache" is not allowed to extend "SpomkyLabs\PwaBundle\Dto\Cache".
-			identifier: ergebnis.noExtends
-			count: 1
-			path: ../src/Dto/ResourceCache.php
-
-		-
 			rawMessage: Class SpomkyLabs\PwaBundle\Dto\ResourceCache has an uninitialized property $matchCallback. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
-			count: 1
-			path: ../src/Dto/ResourceCache.php
-
-		-
-			rawMessage: Class SpomkyLabs\PwaBundle\Dto\ResourceCache is neither abstract nor final.
-			identifier: ergebnis.final
 			count: 1
 			path: ../src/Dto/ResourceCache.php
 
@@ -757,28 +445,22 @@ parameters:
 			path: ../src/Dto/Screenshot.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Screenshot::getLabel() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Dto/Screenshot.php
-
-		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Screenshot::getLabel() should return string|Symfony\Contracts\Translation\TranslatableInterface|null but returns array<string|Symfony\Contracts\Translation\TranslatableInterface>|string|Symfony\Contracts\Translation\TranslatableInterface|null.'
 			identifier: return.type
 			count: 1
 			path: ../src/Dto/Screenshot.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Screenshot::provideTranslation() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
+			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\ScreenshotDimension::getDimensions() should return array{width: int, height: int} but returns array{width: int|null, height: int|null}.'
+			identifier: return.type
 			count: 1
-			path: ../src/Dto/Screenshot.php
+			path: ../src/Dto/ScreenshotDimension.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Screenshot::provideTranslation() has parameter $data with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Dto/Screenshot.php
+			rawMessage: 'Only booleans are allowed in an if condition, int|false given.'
+			identifier: if.condNotBoolean
+			count: 2
+			path: ../src/Dto/ScreenshotDimension.php
 
 		-
 			rawMessage: Class SpomkyLabs\PwaBundle\Dto\ServiceWorker has an uninitialized property $dest. Give it default value or assign it in the constructor.
@@ -799,38 +481,14 @@ parameters:
 			path: ../src/Dto/ShareTarget.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\ShareTargetParameters::getText() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Dto/ShareTargetParameters.php
-
-		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\ShareTargetParameters::getText() should return string|Symfony\Contracts\Translation\TranslatableInterface|null but returns array<string|Symfony\Contracts\Translation\TranslatableInterface>|string|Symfony\Contracts\Translation\TranslatableInterface|null.'
 			identifier: return.type
 			count: 1
 			path: ../src/Dto/ShareTargetParameters.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\ShareTargetParameters::getTitle() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Dto/ShareTargetParameters.php
-
-		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\ShareTargetParameters::getTitle() should return string|Symfony\Contracts\Translation\TranslatableInterface|null but returns array<string|Symfony\Contracts\Translation\TranslatableInterface>|string|Symfony\Contracts\Translation\TranslatableInterface|null.'
 			identifier: return.type
-			count: 1
-			path: ../src/Dto/ShareTargetParameters.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\ShareTargetParameters::provideTranslation() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Dto/ShareTargetParameters.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\ShareTargetParameters::provideTranslation() has parameter $data with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
 			count: 1
 			path: ../src/Dto/ShareTargetParameters.php
 
@@ -847,12 +505,6 @@ parameters:
 			path: ../src/Dto/Shortcut.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Shortcut::getDescription() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Dto/Shortcut.php
-
-		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Shortcut::getDescription() should return string|Symfony\Contracts\Translation\TranslatableInterface|null but returns array<string|Symfony\Contracts\Translation\TranslatableInterface>|string|Symfony\Contracts\Translation\TranslatableInterface|null.'
 			identifier: return.type
 			count: 1
@@ -865,26 +517,8 @@ parameters:
 			path: ../src/Dto/Shortcut.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Shortcut::getShortName() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Dto/Shortcut.php
-
-		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Shortcut::getShortName() should return string|Symfony\Contracts\Translation\TranslatableInterface|null but returns array<string|Symfony\Contracts\Translation\TranslatableInterface>|string|Symfony\Contracts\Translation\TranslatableInterface|null.'
 			identifier: return.type
-			count: 1
-			path: ../src/Dto/Shortcut.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Shortcut::provideTranslation() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Dto/Shortcut.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Shortcut::provideTranslation() has parameter $data with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
 			count: 1
 			path: ../src/Dto/Shortcut.php
 
@@ -901,18 +535,6 @@ parameters:
 			path: ../src/Dto/Theme.php
 
 		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\Dto\Url has parameter $params with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/Dto/Url.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\Dto\Url has parameter $pathTypeReference with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/Dto/Url.php
-
-		-
 			rawMessage: Class SpomkyLabs\PwaBundle\Dto\Widget has an uninitialized property $adaptativeCardTemplate. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
@@ -921,12 +543,6 @@ parameters:
 		-
 			rawMessage: Class SpomkyLabs\PwaBundle\Dto\Widget has an uninitialized property $name. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
-			count: 1
-			path: ../src/Dto/Widget.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Widget::getDescription() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
 			count: 1
 			path: ../src/Dto/Widget.php
 
@@ -943,26 +559,8 @@ parameters:
 			path: ../src/Dto/Widget.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Widget::getShortName() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Dto/Widget.php
-
-		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Widget::getShortName() should return string|Symfony\Contracts\Translation\TranslatableInterface|null but returns array<string|Symfony\Contracts\Translation\TranslatableInterface>|string|Symfony\Contracts\Translation\TranslatableInterface|null.'
 			identifier: return.type
-			count: 1
-			path: ../src/Dto/Widget.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Widget::provideTranslation() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Dto/Widget.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Dto\Widget::provideTranslation() has parameter $data with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
 			count: 1
 			path: ../src/Dto/Widget.php
 
@@ -1036,12 +634,6 @@ parameters:
 			path: ../src/Dto/Workbox.php
 
 		-
-			rawMessage: Class SpomkyLabs\PwaBundle\Event\PreManifestCompileEvent is neither abstract nor final.
-			identifier: ergebnis.final
-			count: 1
-			path: ../src/Event/PreManifestCompileEvent.php
-
-		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\EventListener\EarlyHintsListener::__construct() has parameter $config with no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1060,226 +652,28 @@ parameters:
 			path: ../src/EventListener/FileCompileEventListener.php
 
 		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\EventListener\FileCompileEventListener has parameter $enabled with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/EventListener/FileCompileEventListener.php
-
-		-
 			rawMessage: Instanceof between Symfony\Component\AssetMapper\Event\PreAssetsCompileEvent and Symfony\Component\AssetMapper\Event\PreAssetsCompileEvent will always evaluate to true.
 			identifier: instanceof.alwaysTrue
 			count: 1
 			path: ../src/EventListener/FileCompileEventListener.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\EventListener\PwaDevServerListener::__construct() has parameter $profiler with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
+			rawMessage: 'Only booleans are allowed in a negated boolean, int|false given.'
+			identifier: booleanNot.exprNotBoolean
 			count: 1
-			path: ../src/EventListener/PwaDevServerListener.php
+			path: ../src/EventListener/ManifestScreenshotListener.php
 
 		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\EventListener\ScreenshotListener has parameter $profiler with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
+			rawMessage: Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.
+			identifier: ternary.shortNotAllowed
 			count: 1
-			path: ../src/EventListener/ScreenshotListener.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\EventListener\ScreenshotListener has parameter $userAgent with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/EventListener/ScreenshotListener.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\EventListener\ScreenshotListener::__construct() has parameter $profiler with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/EventListener/ScreenshotListener.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\EventListener\ScreenshotListener::__construct() has parameter $profiler with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/EventListener/ScreenshotListener.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\EventListener\ScreenshotListener::__construct() has parameter $userAgent with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/EventListener/ScreenshotListener.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\EventListener\ScreenshotListener::__construct() has parameter $userAgent with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/EventListener/ScreenshotListener.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\ImageProcessor\Configuration has parameter $backgroundColor with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\ImageProcessor\Configuration has parameter $borderRadius with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\ImageProcessor\Configuration has parameter $imageScale with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\ImageProcessor\Configuration has parameter $monochrome with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\ImageProcessor\Configuration has parameter $svgAttributes with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\Configuration::__construct() has parameter $backgroundColor with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\Configuration::__construct() has parameter $backgroundColor with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\Configuration::__construct() has parameter $borderRadius with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\Configuration::__construct() has parameter $borderRadius with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\Configuration::__construct() has parameter $imageScale with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\Configuration::__construct() has parameter $imageScale with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\Configuration::create() has parameter $backgroundColor with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\Configuration::create() has parameter $backgroundColor with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\Configuration::create() has parameter $borderRadius with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\Configuration::create() has parameter $borderRadius with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\Configuration::create() has parameter $imageScale with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\Configuration::create() has parameter $imageScale with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/ImageProcessor/Configuration.php
+			path: ../src/EventListener/ManifestScreenshotListener.php
 
 		-
 			rawMessage: 'Parameter #9 of function sprintf is expected to be string by placeholder #8 ("%%s"), string|false given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/ImageProcessor/Configuration.php
-
-		-
-			rawMessage: Control structures using switch should not be used.
-			identifier: ergebnis.noSwitch
-			count: 1
-			path: ../src/ImageProcessor/GDImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor::getConfiguration() has parameter $configuration with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/GDImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor::getConfiguration() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/GDImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor::getConfiguration() has parameter $height with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/GDImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor::getConfiguration() has parameter $width with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/GDImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor::process() has parameter $configuration with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/GDImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor::process() has parameter $configuration with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/ImageProcessor/GDImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor::process() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/GDImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor::process() has parameter $height with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/GDImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor::process() has parameter $width with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/GDImageProcessor.php
 
 		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor::process() should return string but returns string|false.'
@@ -1318,182 +712,14 @@ parameters:
 			path: ../src/ImageProcessor/GDImageProcessor.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface::process() has parameter $configuration with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/ImageProcessorInterface.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface::process() has parameter $configuration with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/ImageProcessor/ImageProcessorInterface.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface::process() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/ImageProcessorInterface.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface::process() has parameter $height with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/ImageProcessorInterface.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface::process() has parameter $width with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/ImageProcessorInterface.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor::getConfiguration() has parameter $configuration with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/ImagickImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor::getConfiguration() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/ImagickImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor::getConfiguration() has parameter $height with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/ImagickImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor::getConfiguration() has parameter $width with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/ImagickImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor::process() has parameter $configuration with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/ImagickImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor::process() has parameter $configuration with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/ImageProcessor/ImagickImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor::process() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/ImagickImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor::process() has parameter $height with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/ImagickImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor::process() has parameter $width with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ImageProcessor/ImagickImageProcessor.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\AssetNormalizer::denormalize() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/AssetNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\AssetNormalizer::denormalize() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Normalizer/AssetNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\AssetNormalizer::getSupportedTypes() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/AssetNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\AssetNormalizer::normalize() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/AssetNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\AssetNormalizer::normalize() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Normalizer/AssetNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\AssetNormalizer::supportsDenormalization() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/AssetNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\AssetNormalizer::supportsDenormalization() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Normalizer/AssetNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\AssetNormalizer::supportsNormalization() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/AssetNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\AssetNormalizer::supportsNormalization() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Normalizer/AssetNormalizer.php
-
-		-
 			rawMessage: 'PHPDoc tag @return with type array<string, string> is incompatible with native type string.'
 			identifier: return.phpDocType
 			count: 1
 			path: ../src/Normalizer/AssetNormalizer.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\IconNormalizer::getSupportedTypes() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/IconNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\IconNormalizer::normalize() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/IconNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\IconNormalizer::normalize() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Normalizer/IconNormalizer.php
-
-		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\IconNormalizer::normalize() should return array{src: string, sizes?: string, type?: string, purpose?: string} but returns array<mixed>.'
 			identifier: return.type
-			count: 1
-			path: ../src/Normalizer/IconNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\IconNormalizer::supportsNormalization() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/IconNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\IconNormalizer::supportsNormalization() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
 			count: 1
 			path: ../src/Normalizer/IconNormalizer.php
 
@@ -1504,56 +730,8 @@ parameters:
 			path: ../src/Normalizer/ManifestNormalizer.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ManifestNormalizer::getSupportedTypes() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ManifestNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ManifestNormalizer::normalize() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ManifestNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ManifestNormalizer::normalize() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Normalizer/ManifestNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ManifestNormalizer::supportsNormalization() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ManifestNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ManifestNormalizer::supportsNormalization() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Normalizer/ManifestNormalizer.php
-
-		-
 			rawMessage: 'Cannot cast array<mixed>|ArrayObject<(int|string), mixed>|bool|float|int|string|null to string.'
 			identifier: cast.string
-			count: 1
-			path: ../src/Normalizer/ProtocolHandlerNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ProtocolHandlerNormalizer::getSupportedTypes() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ProtocolHandlerNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ProtocolHandlerNormalizer::normalize() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ProtocolHandlerNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ProtocolHandlerNormalizer::normalize() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
 			count: 1
 			path: ../src/Normalizer/ProtocolHandlerNormalizer.php
 
@@ -1564,178 +742,22 @@ parameters:
 			path: ../src/Normalizer/ProtocolHandlerNormalizer.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ProtocolHandlerNormalizer::supportsNormalization() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ProtocolHandlerNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ProtocolHandlerNormalizer::supportsNormalization() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Normalizer/ProtocolHandlerNormalizer.php
-
-		-
 			rawMessage: 'Parameter #3 $subject of function preg_replace expects array<float|int|string>|string, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/Normalizer/ProtocolHandlerNormalizer.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer::__construct() has parameter $imageProcessor with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ScreenshotNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer::getFormFactor() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ScreenshotNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer::getFormFactor() has parameter $height with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ScreenshotNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer::getFormFactor() has parameter $width with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ScreenshotNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer::getSizes() has parameter $asset with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ScreenshotNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer::getSupportedTypes() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ScreenshotNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer::getType() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ScreenshotNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer::getType() has parameter $asset with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ScreenshotNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer::normalize() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ScreenshotNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer::normalize() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Normalizer/ScreenshotNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer::normalize() should return array{src: string, sizes?: string, form_factor?: string, label?: string, platform?: string, format?: string} but returns array<mixed>.'
+			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer::normalize() should return array{src: string, sizes?: string, form_factor?: string, label?: string, platform?: string, type?: string} but returns array<mixed>.'
 			identifier: return.type
 			count: 1
 			path: ../src/Normalizer/ScreenshotNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer::supportsNormalization() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ScreenshotNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer::supportsNormalization() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Normalizer/ScreenshotNormalizer.php
-
-		-
-			rawMessage: 'Parameter #1 $image of method SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface::getSizes() expects string, string|false given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Normalizer/ScreenshotNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ServiceWorkerNormalizer::getSupportedTypes() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ServiceWorkerNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ServiceWorkerNormalizer::normalize() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ServiceWorkerNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ServiceWorkerNormalizer::normalize() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Normalizer/ServiceWorkerNormalizer.php
 
 		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ServiceWorkerNormalizer::normalize() should return array{scope?: string, src: string, use_cache?: bool} but returns array<mixed>.'
 			identifier: return.type
 			count: 1
 			path: ../src/Normalizer/ServiceWorkerNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ServiceWorkerNormalizer::supportsNormalization() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/ServiceWorkerNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\ServiceWorkerNormalizer::supportsNormalization() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Normalizer/ServiceWorkerNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\UrlNormalizer::getSupportedTypes() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/UrlNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\UrlNormalizer::normalize() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/UrlNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\UrlNormalizer::normalize() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Normalizer/UrlNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\UrlNormalizer::supportsNormalization() has parameter $format with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Normalizer/UrlNormalizer.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Normalizer\UrlNormalizer::supportsNormalization() has parameter $format with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Normalizer/UrlNormalizer.php
-
-		-
-			rawMessage: 'Language construct isset() should not be used.'
-			identifier: ergebnis.noIsset
-			count: 3
-			path: ../src/Resources/config/definition/favicons.php
 
 		-
 			rawMessage: 'Parameter #1 $icons of function expandIcons expects array, mixed given.'
@@ -1894,12 +916,6 @@ parameters:
 			path: ../src/Resources/config/definition/service_worker.php
 
 		-
-			rawMessage: 'Language construct isset() should not be used.'
-			identifier: ergebnis.noIsset
-			count: 5
-			path: ../src/Resources/config/definition/service_worker.php
-
-		-
 			rawMessage: 'Strict comparison using !== between mixed and null will always evaluate to true.'
 			identifier: notIdentical.alwaysTrue
 			count: 3
@@ -1930,18 +946,6 @@ parameters:
 			path: ../src/Resources/config/definition/utils/shortcuts.php
 
 		-
-			rawMessage: 'Function getUrlNode() has parameter $examples with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Resources/config/definition/utils/url_node.php
-
-		-
-			rawMessage: 'Function getUrlNode() has parameter $examples with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Resources/config/definition/utils/url_node.php
-
-		-
 			rawMessage: Access to constant TAG of internal class SpomkyLabs\PwaBundle\CompilerPass\LoggerCompilerPass from outside its root namespace SpomkyLabs.
 			identifier: classConstant.internalClass
 			count: 1
@@ -1952,42 +956,6 @@ parameters:
 			identifier: method.childReturnType
 			count: 1
 			path: ../src/Service/ApplicationIconCompiler.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\Service\Data has parameter $contextFree with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/Service/Data.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\Service\Data has parameter $html with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/Service/Data.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\Data::__construct() has parameter $html with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Service/Data.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\Data::__construct() has parameter $html with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Service/Data.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\Data::create() has parameter $html with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Service/Data.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\Data::create() has parameter $html with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Service/Data.php
 
 		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\Data::getData() should return string but returns Closure|string.'
@@ -2002,32 +970,8 @@ parameters:
 			path: ../src/Service/Data.php
 
 		-
-			rawMessage: Binary operation "." between 'Unable to run…' and mixed results in an error.
-			identifier: binaryOp.invalid
-			count: 1
-			path: ../src/Service/FaviconsCompiler.php
-
-		-
 			rawMessage: 'Call to function assert() with true and string will always evaluate to true.'
 			identifier: function.alreadyNarrowedType
-			count: 1
-			path: ../src/Service/FaviconsCompiler.php
-
-		-
-			rawMessage: 'Call to method getErrorOutput() on an unknown class Symfony\Component\Process\Process.'
-			identifier: class.notFound
-			count: 1
-			path: ../src/Service/FaviconsCompiler.php
-
-		-
-			rawMessage: 'Call to method run() on an unknown class Symfony\Component\Process\Process.'
-			identifier: class.notFound
-			count: 1
-			path: ../src/Service/FaviconsCompiler.php
-
-		-
-			rawMessage: 'Call to method wait() on an unknown class Symfony\Component\Process\Process.'
-			identifier: class.notFound
 			count: 1
 			path: ../src/Service/FaviconsCompiler.php
 
@@ -2038,38 +982,8 @@ parameters:
 			path: ../src/Service/FaviconsCompiler.php
 
 		-
-			rawMessage: Caught class Symfony\Component\Process\Exception\ProcessFailedException not found.
-			identifier: class.notFound
-			count: 1
-			path: ../src/Service/FaviconsCompiler.php
-
-		-
 			rawMessage: Instanceof between Symfony\Component\AssetMapper\MappedAsset and Symfony\Component\AssetMapper\MappedAsset will always evaluate to true.
 			identifier: instanceof.alwaysTrue
-			count: 1
-			path: ../src/Service/FaviconsCompiler.php
-
-		-
-			rawMessage: Instantiated class Symfony\Component\Process\Process not found.
-			identifier: class.notFound
-			count: 1
-			path: ../src/Service/FaviconsCompiler.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface::process() is invoked with named argument for parameter $configuration.'
-			identifier: ergebnis.noNamedArgument
-			count: 1
-			path: ../src/Service/FaviconsCompiler.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\FaviconsCompiler::__construct() has parameter $imageProcessor with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Service/FaviconsCompiler.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\FaviconsCompiler::__construct() has parameter $renderer with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
 			count: 1
 			path: ../src/Service/FaviconsCompiler.php
 
@@ -2077,24 +991,6 @@ parameters:
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\FaviconsCompiler::getFaviconAsset() should return string but returns string|false.'
 			identifier: return.type
 			count: 2
-			path: ../src/Service/FaviconsCompiler.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\FaviconsCompiler::processIcon() has parameter $media with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Service/FaviconsCompiler.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\FaviconsCompiler::processIcon() has parameter $media with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Service/FaviconsCompiler.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\FaviconsCompiler::processIcon() has parameter $rel with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
 			path: ../src/Service/FaviconsCompiler.php
 
 		-
@@ -2116,18 +1012,6 @@ parameters:
 			path: ../src/Service/FaviconsCompiler.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\FileCompiler::compile() has parameter $io with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Service/FileCompiler.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\FileCompiler::compile() has parameter $io with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Service/FileCompiler.php
-
-		-
 			rawMessage: 'Call to function assert() with true and string will always evaluate to true.'
 			identifier: function.alreadyNarrowedType
 			count: 1
@@ -2136,36 +1020,6 @@ parameters:
 		-
 			rawMessage: Instanceof between Symfony\Component\AssetMapper\MappedAsset and Symfony\Component\AssetMapper\MappedAsset will always evaluate to true.
 			identifier: instanceof.alwaysTrue
-			count: 1
-			path: ../src/Service/IconResolver.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface::process() is invoked with named argument for parameter $configuration.'
-			identifier: ergebnis.noNamedArgument
-			count: 1
-			path: ../src/Service/IconResolver.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\IconResolver::__construct() has parameter $imageProcessor with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Service/IconResolver.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\IconResolver::__construct() has parameter $renderer with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Service/IconResolver.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\IconResolver::getType() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Service/IconResolver.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\IconResolver::getType() has parameter $type with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
 			count: 1
 			path: ../src/Service/IconResolver.php
 
@@ -2204,18 +1058,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../src/Service/IconResolver.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\ManifestCompiler::__construct() has parameter $dispatcher with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Service/ManifestCompiler.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\ManifestCompiler::compileManifest() has parameter $locale with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Service/ManifestCompiler.php
 
 		-
 			rawMessage: Cannot access offset 'enabled' on mixed.
@@ -2272,34 +1114,70 @@ parameters:
 			path: ../src/Service/ResourceHintsBuilder.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\ServiceWorkerCompiler::getIndexDBFile() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
+			rawMessage: 'Cannot call method process() on SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface|null.'
+			identifier: method.nonObject
 			count: 1
-			path: ../src/Service/ServiceWorkerCompiler.php
+			path: ../src/Service/ScreenshotGenerator.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\ServiceWorkerCompiler::getWorkboxFile() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
+			rawMessage: Cannot cast mixed to string.
+			identifier: cast.string
 			count: 1
-			path: ../src/Service/ServiceWorkerCompiler.php
+			path: ../src/Service/ScreenshotGenerator.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\SpeculationRulesBuilder::buildSingleRule() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
+			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\ScreenshotGenerator::getAvailablePort() should return int but returns mixed.'
+			identifier: return.type
 			count: 1
-			path: ../src/Service/SpeculationRulesBuilder.php
+			path: ../src/Service/ScreenshotGenerator.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\SpeculationRulesBuilder::buildWhereClause() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
+			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\ScreenshotGenerator::getDefaultArguments() return type has no value type specified in iterable type array.'
+			identifier: missingType.iterableValue
 			count: 1
-			path: ../src/Service/SpeculationRulesBuilder.php
+			path: ../src/Service/ScreenshotGenerator.php
 
 		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\SpeculationRulesBuilder::generateJson() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
+			rawMessage: 'Only booleans are allowed in &&, mixed given on the right side.'
+			identifier: booleanAnd.rightNotBoolean
 			count: 1
-			path: ../src/Service/SpeculationRulesBuilder.php
+			path: ../src/Service/ScreenshotGenerator.php
+
+		-
+			rawMessage: 'Only booleans are allowed in a negated boolean, mixed given.'
+			identifier: booleanNot.exprNotBoolean
+			count: 1
+			path: ../src/Service/ScreenshotGenerator.php
+
+		-
+			rawMessage: 'Only booleans are allowed in an if condition, mixed given.'
+			identifier: if.condNotBoolean
+			count: 2
+			path: ../src/Service/ScreenshotGenerator.php
+
+		-
+			rawMessage: 'Parameter #1 $chromeDriverBinary of static method Symfony\Component\Panther\Client::createChromeClient() expects string|null, mixed given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/Service/ScreenshotGenerator.php
+
+		-
+			rawMessage: 'Parameter #2 $arguments of static method Symfony\Component\Panther\Client::createChromeClient() expects array<string>|null, array given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/Service/ScreenshotGenerator.php
+
+		-
+			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\ScreenshotUrlGenerator::generateUrl() should return string but returns string|null.'
+			identifier: return.type
+			count: 1
+			path: ../src/Service/ScreenshotUrlGenerator.php
+
+		-
+			rawMessage: 'Parameter #1 $name of method Symfony\Component\Routing\Generator\UrlGeneratorInterface::generate() expects string, string|null given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/Service/ScreenshotUrlGenerator.php
 
 		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Service\SpeculationRulesBuilder::isEnabled() should return bool but returns mixed.'
@@ -2332,30 +1210,6 @@ parameters:
 			path: ../src/ServiceWorkerRule/BackgroundFetchCache.php
 
 		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\ServiceWorkerRule\BackgroundFetchCache has parameter $translator with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/ServiceWorkerRule/BackgroundFetchCache.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ServiceWorkerRule\BackgroundFetchCache::__construct() has parameter $translator with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/ServiceWorkerRule/BackgroundFetchCache.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\ServiceWorkerRule\BackgroundFetchCache::__construct() has parameter $translator with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/ServiceWorkerRule/BackgroundFetchCache.php
-
-		-
-			rawMessage: 'Language construct isset() should not be used.'
-			identifier: ergebnis.noIsset
-			count: 1
-			path: ../src/ServiceWorkerRule/OfflineFallback.php
-
-		-
 			rawMessage: 'Strict comparison using === between int<1, max> and 0 will always evaluate to false.'
 			identifier: identical.alwaysFalse
 			count: 2
@@ -2370,12 +1224,6 @@ parameters:
 		-
 			rawMessage: 'Construct empty() is not allowed. Use more strict comparison.'
 			identifier: empty.notAllowed
-			count: 1
-			path: ../src/ServiceWorkerRule/WorkboxImport.php
-
-		-
-			rawMessage: 'Language construct isset() should not be used.'
-			identifier: ergebnis.noIsset
 			count: 1
 			path: ../src/ServiceWorkerRule/WorkboxImport.php
 
@@ -2404,38 +1252,8 @@ parameters:
 			path: ../src/SpomkyLabsPwaBundle.php
 
 		-
-			rawMessage: Class "SpomkyLabs\PwaBundle\SpomkyLabsPwaBundle" is not allowed to extend "Symfony\Component\HttpKernel\Bundle\AbstractBundle".
-			identifier: ergebnis.noExtends
-			count: 1
-			path: ../src/SpomkyLabsPwaBundle.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\SpomkyLabsPwaBundle::build() has a parameter $container with a type declaration of Symfony\Component\DependencyInjection\ContainerBuilder, but containers should not be injected.'
-			identifier: ergebnis.noParameterWithContainerTypeDeclaration
-			count: 1
-			path: ../src/SpomkyLabsPwaBundle.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\SpomkyLabsPwaBundle::loadExtension() has a parameter $builder with a type declaration of Symfony\Component\DependencyInjection\ContainerBuilder, but containers should not be injected.'
-			identifier: ergebnis.noParameterWithContainerTypeDeclaration
-			count: 1
-			path: ../src/SpomkyLabsPwaBundle.php
-
-		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\SpomkyLabsPwaBundle::loadExtension() has parameter $config with no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/SpomkyLabsPwaBundle.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\SpomkyLabsPwaBundle::prependExtension() has a parameter $builder with a type declaration of Symfony\Component\DependencyInjection\ContainerBuilder, but containers should not be injected.'
-			identifier: ergebnis.noParameterWithContainerTypeDeclaration
-			count: 1
-			path: ../src/SpomkyLabsPwaBundle.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\SpomkyLabsPwaBundle::setAssetMapperPath() has a parameter $builder with a type declaration of Symfony\Component\DependencyInjection\ContainerBuilder, but containers should not be injected.'
-			identifier: ergebnis.noParameterWithContainerTypeDeclaration
 			count: 1
 			path: ../src/SpomkyLabsPwaBundle.php
 
@@ -2452,139 +1270,13 @@ parameters:
 			path: ../src/SpomkyLabsPwaBundle.php
 
 		-
-			rawMessage: Class SpomkyLabs\PwaBundle\Twig\InstanceOfExtension is neither abstract nor final.
-			identifier: ergebnis.final
-			count: 1
-			path: ../src/Twig/InstanceOfExtension.php
-
-		-
 			rawMessage: 'Method SpomkyLabs\PwaBundle\Twig\InstanceOfExtension::getTests() return type has no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
 			count: 1
 			path: ../src/Twig/InstanceOfExtension.php
 
 		-
-			rawMessage: Class "SpomkyLabs\PwaBundle\Twig\PwaExtension" is not allowed to extend "Twig\Extension\AbstractExtension".
-			identifier: ergebnis.noExtends
-			count: 1
-			path: ../src/Twig/PwaExtension.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\Twig\PwaRuntime has parameter $cspListener with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/Twig/PwaRuntime.php
-
-		-
-			rawMessage: 'Language construct isset() should not be used.'
-			identifier: ergebnis.noIsset
-			count: 2
-			path: ../src/Twig/PwaRuntime.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Twig\PwaRuntime::__construct() has parameter $cspListener with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Twig/PwaRuntime.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Twig\PwaRuntime::__construct() has parameter $cspListener with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Twig/PwaRuntime.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Twig\PwaRuntime::getLocale() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/Twig/PwaRuntime.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Twig\PwaRuntime::getLocale() has parameter $locale with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Twig/PwaRuntime.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Twig\PwaRuntime::getLocale() has parameter $locale with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Twig/PwaRuntime.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Twig\PwaRuntime::injectManifestFile() has parameter $locale with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Twig/PwaRuntime.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Twig\PwaRuntime::load() has parameter $locale with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/Twig/PwaRuntime.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\Twig\PwaRuntime::load() has parameter $locale with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/Twig/PwaRuntime.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\WorkboxPlugin\BackgroundSyncPlugin::__construct() has parameter $broadcastChannel with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/WorkboxPlugin/BackgroundSyncPlugin.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\WorkboxPlugin\BackgroundSyncPlugin::create() has parameter $broadcastChannel with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/WorkboxPlugin/BackgroundSyncPlugin.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\WorkboxPlugin\BroadcastUpdatePlugin has parameter $headersToCheck with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/WorkboxPlugin/BroadcastUpdatePlugin.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\WorkboxPlugin\CacheableResponsePlugin has parameter $headers with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/WorkboxPlugin/CacheableResponsePlugin.php
-
-		-
-			rawMessage: Constructor in SpomkyLabs\PwaBundle\WorkboxPlugin\CacheableResponsePlugin has parameter $statuses with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/WorkboxPlugin/CacheableResponsePlugin.php
-
-		-
 			rawMessage: 'Parameter #2 of function sprintf is expected to be string by placeholder #1 ("%%s"), string|false given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/WorkboxPlugin/CacheableResponsePlugin.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\WorkboxPlugin\ExpirationPlugin::__construct() has parameter $maxAgeSeconds with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/WorkboxPlugin/ExpirationPlugin.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\WorkboxPlugin\ExpirationPlugin::__construct() has parameter $maxEntries with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/WorkboxPlugin/ExpirationPlugin.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\WorkboxPlugin\ExpirationPlugin::create() has parameter $maxAgeSeconds with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/WorkboxPlugin/ExpirationPlugin.php
-
-		-
-			rawMessage: 'Method SpomkyLabs\PwaBundle\WorkboxPlugin\ExpirationPlugin::create() has parameter $maxEntries with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/WorkboxPlugin/ExpirationPlugin.php

--- a/.ci-tools/phpstan.neon
+++ b/.ci-tools/phpstan.neon
@@ -17,7 +17,7 @@ includes:
 	- %rootDir%/../phpstan-beberlei-assert/extension.neon
 	- %rootDir%/../phpstan-deprecation-rules/rules.neon
 	- %rootDir%/../phpstan-doctrine/extension.neon
-	- %rootDir%/../../ergebnis/phpstan-rules/rules.neon
+	#- %rootDir%/../../ergebnis/phpstan-rules/rules.neon
 	- %rootDir%/../phpstan-phpunit/extension.neon
 	- %rootDir%/../phpstan-strict-rules/rules.neon
 	- %rootDir%/../phpstan-symfony/extension.neon

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -185,6 +185,9 @@ jobs:
         with:
           dependency-versions: ${{ matrix.lowest-deps && 'lowest' || 'highest' }}
           composer-options: --no-interaction --no-progress --optimize-autoloader
+      - name: "Downgrade phpdocumentor/reflection-docblock"
+        run: composer require phpdocumentor/reflection-docblock ^5.3
+
       - name: Run PHPUnit
         run: castor phpunit
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -186,7 +186,7 @@ jobs:
           dependency-versions: ${{ matrix.lowest-deps && 'lowest' || 'highest' }}
           composer-options: --no-interaction --no-progress --optimize-autoloader
       - name: "Downgrade phpdocumentor/reflection-docblock"
-        run: composer require phpdocumentor/reflection-docblock ^5.3
+        run: composer require -W phpdocumentor/reflection-docblock ^5.3
 
       - name: Run PHPUnit
         run: castor phpunit

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
     "matthiasnoback/symfony-config-test": "^5.1|^6.0",
     "monolog/monolog": "^3.0",
     "nelmio/security-bundle": "^3.3",
-    "phpdocumentor/reflection-docblock": "^5.3",
     "symfony/console": "^6.4|^7.0|^8.0",
     "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
     "symfony/filesystem": "^6.4|^7.0|^8.0",

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "twig/twig": "^3.8"
     },
     "require-dev": {
+        "dbrekelmans/bdi": "*",
         "matthiasnoback/symfony-config-test": "^5.1|^6.0",
         "monolog/monolog": "^3.0",
         "nelmio/security-bundle": "^3.3",
@@ -60,6 +61,7 @@
         "symfony/mime": "^6.4|^7.0|^8.0",
         "symfony/monolog-bridge": "^6.4|^7.0|^8.0",
         "symfony/monolog-bundle": "^3.10|^4.0",
+        "symfony/panther": "^2.3",
         "symfony/translation": "^6.4|^7.0|^8.0",
         "symfony/twig-bundle": "^7.0|^8.0",
         "symfony/ux-icons": "^2.29",

--- a/composer.json
+++ b/composer.json
@@ -1,86 +1,87 @@
 {
-    "name": "spomky-labs/pwa-bundle",
-    "description": "Progressive Web App Manifest Generator Bundle for Symfony.",
-    "type": "symfony-bundle",
-    "license": "MIT",
-    "keywords": [
-        "symfony-ux",
-        "PWA",
-        "Bundle",
-        "Symfony"
-    ],
-    "homepage": "https://github.com/spomky-labs",
-    "authors": [
-        {
-            "name": "Florent Morselli",
-            "homepage": "https://github.com/Spomky"
-        },
-        {
-            "name": "All contributors",
-            "homepage": "https://github.com/spomky-labs/pwa-bundle/contributors"
-        }
-    ],
-    "autoload": {
-        "psr-4": {
-            "SpomkyLabs\\PwaBundle\\": "src/"
-        }
+  "name": "spomky-labs/pwa-bundle",
+  "description": "Progressive Web App Manifest Generator Bundle for Symfony.",
+  "type": "symfony-bundle",
+  "license": "MIT",
+  "keywords": [
+    "symfony-ux",
+    "PWA",
+    "Bundle",
+    "Symfony"
+  ],
+  "homepage": "https://github.com/spomky-labs",
+  "authors": [
+    {
+      "name": "Florent Morselli",
+      "homepage": "https://github.com/Spomky"
     },
-    "autoload-dev": {
-        "psr-4": {
-            "SpomkyLabs\\PwaBundle\\Tests\\": "tests/"
-        }
-    },
-    "require": {
-        "php": ">=8.2",
-        "phpdocumentor/reflection-docblock": "^5.3|^6.0",
-        "psr/log": "^1.1|^2.0|^3.0",
-        "symfony/asset": "^6.4|^7.0|^8.0",
-        "symfony/asset-mapper": "^6.4|^7.0|^8.0",
-        "symfony/config": "^6.4|^7.0|^8.0",
-        "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-        "symfony/deprecation-contracts": "^3.5",
-        "symfony/http-kernel": "^6.4|^7.0|^8.0",
-        "symfony/property-access": "^6.4|^7.0|^8.0",
-        "symfony/property-info": "^6.4|^7.0|^8.0",
-        "symfony/routing": "^6.4|^7.0|^8.0",
-        "symfony/serializer": "^6.4|^7.0|^8.0",
-        "symfony/service-contracts": "^3.0",
-        "symfony/web-link": "^6.4|^7.0|^8.0",
-        "twig/twig": "^3.8"
-    },
-    "require-dev": {
-        "dbrekelmans/bdi": "*",
-        "matthiasnoback/symfony-config-test": "^5.1|^6.0",
-        "monolog/monolog": "^3.0",
-        "nelmio/security-bundle": "^3.3",
-        "symfony/console": "^6.4|^7.0|^8.0",
-        "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-        "symfony/filesystem": "^6.4|^7.0|^8.0",
-        "symfony/finder": "^6.4|^7.0|^8.0",
-        "symfony/framework-bundle": "^7.0|^8.0",
-        "symfony/mime": "^6.4|^7.0|^8.0",
-        "symfony/monolog-bridge": "^6.4|^7.0|^8.0",
-        "symfony/monolog-bundle": "^3.10|^4.0",
-        "symfony/panther": "^2.3",
-        "symfony/translation": "^6.4|^7.0|^8.0",
-        "symfony/twig-bundle": "^7.0|^8.0",
-        "symfony/ux-icons": "^2.29",
-        "symfony/yaml": "^6.4|^7.0|^8.0"
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "extra": {
-        "thanks": {
-            "name": "spomky-labs/pwa-bundle",
-            "url": "https://github.com/spomky-labs/pwa-bundle"
-        }
-    },
-    "suggest": {
-        "ext-gd": "Required to generate icons (or Imagick).",
-        "ext-imagick": "Required to generate icons (or GD).",
-        "symfony/mime": "For generating and manipulating icons or screenshots",
-        "symfony/filesystem": "For generating and manipulating icons or screenshots",
-        "symfony/ux-icons": "For using SVG icons (e.g. for shortcuts)"
+    {
+      "name": "All contributors",
+      "homepage": "https://github.com/spomky-labs/pwa-bundle/contributors"
     }
+  ],
+  "autoload": {
+    "psr-4": {
+      "SpomkyLabs\\PwaBundle\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "SpomkyLabs\\PwaBundle\\Tests\\": "tests/"
+    }
+  },
+  "require": {
+    "php": ">=8.2",
+    "phpdocumentor/reflection-docblock": "^5.3|^6.0",
+    "psr/log": "^1.1|^2.0|^3.0",
+    "symfony/asset": "^6.4|^7.0|^8.0",
+    "symfony/asset-mapper": "^6.4|^7.0|^8.0",
+    "symfony/config": "^6.4|^7.0|^8.0",
+    "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+    "symfony/deprecation-contracts": "^3.5",
+    "symfony/http-kernel": "^6.4|^7.0|^8.0",
+    "symfony/property-access": "^6.4|^7.0|^8.0",
+    "symfony/property-info": "^6.4|^7.0|^8.0",
+    "symfony/routing": "^6.4|^7.0|^8.0",
+    "symfony/serializer": "^6.4|^7.0|^8.0",
+    "symfony/service-contracts": "^3.0",
+    "symfony/web-link": "^6.4|^7.0|^8.0",
+    "twig/twig": "^3.8"
+  },
+  "require-dev": {
+    "dbrekelmans/bdi": "*",
+    "matthiasnoback/symfony-config-test": "^5.1|^6.0",
+    "monolog/monolog": "^3.0",
+    "nelmio/security-bundle": "^3.3",
+    "phpdocumentor/reflection-docblock": "^5.3",
+    "symfony/console": "^6.4|^7.0|^8.0",
+    "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+    "symfony/filesystem": "^6.4|^7.0|^8.0",
+    "symfony/finder": "^6.4|^7.0|^8.0",
+    "symfony/framework-bundle": "^7.0|^8.0",
+    "symfony/mime": "^6.4|^7.0|^8.0",
+    "symfony/monolog-bridge": "^6.4|^7.0|^8.0",
+    "symfony/monolog-bundle": "^3.10|^4.0",
+    "symfony/panther": "^2.3",
+    "symfony/translation": "^6.4|^7.0|^8.0",
+    "symfony/twig-bundle": "^7.0|^8.0",
+    "symfony/ux-icons": "^2.29",
+    "symfony/yaml": "^6.4|^7.0|^8.0"
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "extra": {
+    "thanks": {
+      "name": "spomky-labs/pwa-bundle",
+      "url": "https://github.com/spomky-labs/pwa-bundle"
+    }
+  },
+  "suggest": {
+    "ext-gd": "Required to generate icons (or Imagick).",
+    "ext-imagick": "Required to generate icons (or GD).",
+    "symfony/mime": "For generating and manipulating icons or screenshots",
+    "symfony/filesystem": "For generating and manipulating icons or screenshots",
+    "symfony/ux-icons": "For using SVG icons (e.g. for shortcuts)"
+  }
 }

--- a/src/Attribute/Screenshot.php
+++ b/src/Attribute/Screenshot.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+readonly class Screenshot
+{
+    /**
+     * @param array<string> $sizes Size profiles or explicit dimensions (e.g., ["fhd", "ipad/LP", "1920x1080"])
+     * @param array<string, mixed> $parameters Route parameters (e.g., ["id" => 123]). Note: use locales parameter for _locale
+     * @param array<string> $locales Locales to generate screenshots for (e.g., ["fr", "en"]). Each locale generates separate screenshots
+     * @param null|string $name Base filename for the screenshots (without extension)
+     * @param null|string $label Label for the screenshot in the manifest (supports translation)
+     * @param null|string $platform Target platform (e.g., "android", "ios", "windows")
+     * @param null|string $output Output directory for the screenshots
+     * @param null|string $format Output format (e.g., "png", "jpg", "webp")
+     */
+    public function __construct(
+        public array $sizes = [],
+        public array $parameters = [],
+        public array $locales = [],
+        public null|string $name = null,
+        public null|string $label = null,
+        public null|string $platform = null,
+        public null|string $output = null,
+        public null|string $format = null,
+    ) {
+    }
+}

--- a/src/Command/CompileCommand.php
+++ b/src/Command/CompileCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SpomkyLabs\PwaBundle\Command;
 
 use SpomkyLabs\PwaBundle\Service\FileCompiler;
+use SpomkyLabs\PwaBundle\Service\ScreenshotGenerator;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,6 +18,7 @@ final class CompileCommand extends Command
 {
     public function __construct(
         private readonly FileCompiler $compiler,
+        private readonly null|ScreenshotGenerator $screenshotGenerator = null,
     ) {
         parent::__construct();
     }
@@ -29,11 +31,22 @@ final class CompileCommand extends Command
             InputOption::VALUE_NONE,
             'Compile only assets that depend on the application context (e.g. the manifest).'
         );
+        $this->addOption('no-screenshots', null, InputOption::VALUE_NONE, 'Skip screenshot generation.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+        $noScreenshots = (bool) $input->getOption('no-screenshots');
+
+        // Generate screenshots if the generator is available and not skipped
+        if (! $noScreenshots && $this->screenshotGenerator?->isEnabled()) {
+            $io->title('Generating screenshots');
+            if (! $this->screenshotGenerator->generate($io)) {
+                return self::FAILURE;
+            }
+        }
+
         $contextOnly = (bool) $input->getOption('context-only');
 
         $io->title('Compiling the PWA assets');

--- a/src/Command/CreateScreenshotCommand.php
+++ b/src/Command/CreateScreenshotCommand.php
@@ -125,7 +125,7 @@ final class CreateScreenshotCommand extends Command
         $client->takeScreenshot($tmpName);
         try {
             $client->waitFor('title', 5, 500);
-            $result = preg_match("/<title>(.+)<\/title>/i", (string) $crawler->html(), $title);
+            $result = preg_match("/<title>(.+)<\/title>/i", $crawler->html(), $title);
             $title = $result === 1 ? $title[1] : null;
         } catch (Throwable) {
             $title = null;

--- a/src/Dto/Screenshot.php
+++ b/src/Dto/Screenshot.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\PwaBundle\Dto;
 
+use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\Serializer\Attribute\SerializedName;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
@@ -27,6 +28,12 @@ final class Screenshot
     public null|string $platform = null;
 
     public null|string $type = null;
+
+    /**
+     * Locale for which this screenshot is intended. Used for filtering, not serialized.
+     */
+    #[Ignore]
+    public null|string $locale = null;
 
     public function getLabel(): null|string|TranslatableInterface
     {

--- a/src/Dto/ScreenshotConfiguration.php
+++ b/src/Dto/ScreenshotConfiguration.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Dto;
+
+use function array_map;
+use function implode;
+use InvalidArgumentException;
+use function is_array;
+use function is_string;
+use function sprintf;
+
+final readonly class ScreenshotConfiguration
+{
+    /**
+     * @param array<ScreenshotDimension> $sizes
+     * @param array<string, mixed> $routeParameters
+     */
+    public function __construct(
+        public null|string $url = null,
+        public null|string $route = null,
+        public array $routeParameters = [],
+        public string $output = '',
+        public string $filename = 'screenshot',
+        public array $sizes = [],
+        public null|string $platform = null,
+        public null|string $locale = null,
+        public null|string $label = null,
+        public string $format = 'png',
+    ) {
+    }
+
+    public function isRoute(): bool
+    {
+        return $this->route !== null;
+    }
+
+    /**
+     * @param array{url?: string, route?: string, parameters?: array<string, mixed>, output?: string, filename?: string, sizes?: array<string>|string, platform?: string} $data
+     */
+    public static function fromArray(array $data, string $defaultOutput): self
+    {
+        $sizesData = $data['sizes'] ?? [];
+        if (is_string($sizesData)) {
+            $sizesData = [$sizesData];
+        }
+
+        $sizes = [];
+        $invalidSizes = [];
+
+        foreach ($sizesData as $sizeStr) {
+            $expandedSizes = ScreenshotDimension::expandFromString($sizeStr);
+            if ($expandedSizes === []) {
+                $invalidSizes[] = $sizeStr;
+            } else {
+                foreach ($expandedSizes as $size) {
+                    $sizes[] = $size;
+                }
+            }
+        }
+
+        if ($invalidSizes !== []) {
+            $suggestions = [];
+            foreach ($invalidSizes as $invalid) {
+                $suggestion = ScreenshotSize::getSuggestion($invalid);
+                $suggestions[] = $suggestion !== null
+                    ? sprintf('"%s" (did you mean "%s"?)', $invalid, $suggestion)
+                    : sprintf('"%s"', $invalid);
+            }
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid screenshot size(s): %s. Valid profile names: %s, or use explicit dimensions like "1920x1080"',
+                    implode(', ', $suggestions),
+                    implode(', ', ScreenshotSize::getAllProfileNames())
+                )
+            );
+        }
+
+        // Parse URL or route
+        $url = $data['url'] ?? null;
+        $route = $data['route'] ?? null;
+        $routeParameters = [];
+
+        if ($route !== null && is_string($route)) {
+            $routeParameters = $data['parameters'] ?? [];
+            if (! is_array($routeParameters)) {
+                throw new InvalidArgumentException('Route parameters must be an array.');
+            }
+        }
+
+        return new self(
+            url: $url,
+            route: $route,
+            routeParameters: $routeParameters,
+            output: $data['output'] ?? $defaultOutput,
+            filename: $data['filename'] ?? 'screenshot',
+            sizes: $sizes,
+            platform: $data['platform'] ?? null,
+            locale: $data['locale'] ?? null,
+            label: $data['label'] ?? null,
+            format: $data['format'] ?? 'png',
+        );
+    }
+
+    public function validate(): null|string
+    {
+        if ($this->url === null && $this->route === null) {
+            return 'Either "url" or "route" must be specified.';
+        }
+
+        if ($this->url !== null && $this->route !== null) {
+            return 'Cannot specify both "url" and "route". Choose one.';
+        }
+
+        if ($this->sizes === []) {
+            return 'At least one size must be specified.';
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<array{size: ScreenshotDimension, width: int, height: int, formFactor: string}>
+     */
+    public function getExpandedSizes(): array
+    {
+        return array_map(
+            static fn (ScreenshotDimension $size) => [
+                'size' => $size,
+                'width' => $size->getDimensions()['width'],
+                'height' => $size->getDimensions()['height'],
+                'formFactor' => $size->getFormFactor(),
+            ],
+            $this->sizes
+        );
+    }
+}

--- a/src/Dto/ScreenshotDimension.php
+++ b/src/Dto/ScreenshotDimension.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Dto;
+
+use function preg_match;
+use function sprintf;
+
+final readonly class ScreenshotDimension
+{
+    private function __construct(
+        private null|ScreenshotSize $profile,
+        private null|int $width,
+        private null|int $height,
+        private string $label,
+    ) {
+    }
+
+    public static function fromProfile(ScreenshotSize $profile): self
+    {
+        return new self($profile, null, null, $profile->getLabel());
+    }
+
+    public static function fromDimensions(int $width, int $height): self
+    {
+        $label = sprintf('%d×%d', $width, $height);
+        return new self(null, $width, $height, $label);
+    }
+
+    /**
+     * Parse a size string that can be either:
+     * - A profile name (e.g., "fhd", "iphone-14")
+     * - Explicit dimensions (e.g., "1920x1080", "1920×1080")
+     */
+    public static function fromString(string $value): ?self
+    {
+        // Try as profile first
+        $profile = ScreenshotSize::fromString($value);
+        if ($profile !== null) {
+            return self::fromProfile($profile);
+        }
+
+        // Try to parse as dimensions (e.g., "1920x1080" or "1920×1080")
+        if (preg_match('/^(\d+)[x×](\d+)$/i', $value, $matches)) {
+            $width = (int) $matches[1];
+            $height = (int) $matches[2];
+            if ($width > 0 && $height > 0) {
+                return self::fromDimensions($width, $height);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Expand a size string into one or more dimensions, supporting orientation selectors:
+     * - "ipad" → Default orientation from profile
+     * - "ipad/L" → Landscape only (width > height)
+     * - "ipad/P" → Portrait only (width < height)
+     * - "ipad/LP" → Both landscape AND portrait
+     * - "1920x1080/P" → Portrait version (1080×1920)
+     *
+     * @return array<self>
+     */
+    public static function expandFromString(string $value): array
+    {
+        // Check for orientation suffix: /L, /P, or /LP
+        if (preg_match('/^(.+)\/(L|P|LP)$/i', $value, $matches)) {
+            $baseValue = $matches[1];
+            $orientation = strtoupper($matches[2]);
+
+            // Parse the base profile or dimensions
+            $baseDimension = self::fromString($baseValue);
+            if ($baseDimension === null) {
+                return [];
+            }
+
+            $dims = $baseDimension->getDimensions();
+            $width = $dims['width'];
+            $height = $dims['height'];
+
+            // Ensure we have landscape and portrait versions
+            $landscapeWidth = max($width, $height);
+            $landscapeHeight = min($width, $height);
+            $portraitWidth = $landscapeHeight;
+            $portraitHeight = $landscapeWidth;
+
+            $result = [];
+
+            if ($orientation === 'L') {
+                // Landscape only
+                $label = $baseDimension->getLabel() . ' (Landscape)';
+                $result[] = new self(null, $landscapeWidth, $landscapeHeight, $label);
+            } elseif ($orientation === 'P') {
+                // Portrait only
+                $label = $baseDimension->getLabel() . ' (Portrait)';
+                $result[] = new self(null, $portraitWidth, $portraitHeight, $label);
+            } else {
+                // LP - Both orientations
+                $labelBase = $baseDimension->getLabel();
+                $result[] = new self(null, $portraitWidth, $portraitHeight, $labelBase . ' (Portrait)');
+                $result[] = new self(null, $landscapeWidth, $landscapeHeight, $labelBase . ' (Landscape)');
+            }
+
+            return $result;
+        }
+
+        // No orientation suffix - use default
+        $dimension = self::fromString($value);
+        return $dimension !== null ? [$dimension] : [];
+    }
+
+    /**
+     * @return array{width: int, height: int}
+     */
+    public function getDimensions(): array
+    {
+        if ($this->profile !== null) {
+            return $this->profile->getDimensions();
+        }
+
+        return [
+            'width' => $this->width,
+            'height' => $this->height,
+        ];
+    }
+
+    public function getFormFactor(): string
+    {
+        if ($this->profile !== null) {
+            return $this->profile->getFormFactor();
+        }
+
+        return $this->width > $this->height ? 'wide' : 'narrow';
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function isProfile(): bool
+    {
+        return $this->profile !== null;
+    }
+
+    public function getProfileName(): ?string
+    {
+        return $this->profile?->value;
+    }
+}

--- a/src/Dto/ScreenshotSize.php
+++ b/src/Dto/ScreenshotSize.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Dto;
+
+use const PHP_INT_MAX;
+
+enum ScreenshotSize: string
+{
+    // Standard resolutions (landscape - wide)
+    case HD = 'hd';                    // 1280x720
+    case FULL_HD = 'fhd';              // 1920x1080
+    case QHD = '2k';                   // 2560x1440
+    case UHD = '4k';                   // 3840x2160
+    case UHD_8K = '8k';                // 7680x4320
+
+    // Portrait resolutions (narrow)
+    case P_480 = '480p';               // 640x480
+    case P_720 = '720p';               // 720x1280
+    case P_1080 = '1080p';             // 1080x1920
+    case P_1440 = '1440p';             // 1440x2560
+
+    // iPhone models (narrow)
+    case IPHONE_SE = 'iphone-se';      // 375x667
+    case IPHONE_8 = 'iphone-8';        // 375x667
+    case IPHONE_12 = 'iphone-12';      // 390x844
+    case IPHONE_13 = 'iphone-13';      // 390x844
+    case IPHONE_14 = 'iphone-14';      // 390x844
+    case IPHONE_14_PLUS = 'iphone-14-plus';      // 428x926
+    case IPHONE_14_PRO = 'iphone-14-pro';        // 393x852
+    case IPHONE_14_PRO_MAX = 'iphone-14-pro-max'; // 430x932
+    case IPHONE_15 = 'iphone-15';      // 393x852
+    case IPHONE_15_PRO_MAX = 'iphone-15-pro-max'; // 430x932
+
+    // Android popular devices (narrow)
+    case PIXEL_5 = 'pixel-5';          // 393x851
+    case PIXEL_6 = 'pixel-6';          // 412x915
+    case PIXEL_7 = 'pixel-7';          // 412x915
+    case PIXEL_7_PRO = 'pixel-7-pro';  // 412x915
+    case GALAXY_S21 = 'galaxy-s21';    // 360x800
+    case GALAXY_S22 = 'galaxy-s22';    // 360x800
+    case GALAXY_S23 = 'galaxy-s23';    // 360x780
+
+    // Tablets
+    case IPAD = 'ipad';                // 768x1024 (portrait) - use /L for landscape, /LP for both
+    case IPAD_PRO_11 = 'ipad-pro-11';  // 834x1194 (portrait) - use /L for landscape, /LP for both
+    case IPAD_PRO_129 = 'ipad-pro-129'; // 1024x1366 (portrait) - use /L for landscape, /LP for both
+
+    // Common web breakpoints (wide)
+    case MOBILE_SM = 'mobile-sm';      // 320x568
+    case MOBILE_MD = 'mobile-md';      // 375x667
+    case MOBILE_LG = 'mobile-lg';      // 414x896
+    case TABLET = 'tablet';            // 768x1024
+    case DESKTOP_SM = 'desktop-sm';    // 1024x768
+    case DESKTOP_MD = 'desktop-md';    // 1366x768
+    case DESKTOP_LG = 'desktop-lg';    // 1920x1080
+    case DESKTOP_XL = 'desktop-xl';    // 2560x1440
+
+    /**
+     * @return array{width: int, height: int}
+     */
+    public function getDimensions(): array
+    {
+        return match ($this) {
+            // Standard resolutions (landscape)
+            self::HD => [
+                'width' => 1280,
+                'height' => 720,
+            ],
+            self::FULL_HD => [
+                'width' => 1920,
+                'height' => 1080,
+            ],
+            self::QHD => [
+                'width' => 2560,
+                'height' => 1440,
+            ],
+            self::UHD => [
+                'width' => 3840,
+                'height' => 2160,
+            ],
+            self::UHD_8K => [
+                'width' => 7680,
+                'height' => 4320,
+            ],
+
+            // Portrait resolutions
+            self::P_480 => [
+                'width' => 640,
+                'height' => 480,
+            ],
+            self::P_720 => [
+                'width' => 720,
+                'height' => 1280,
+            ],
+            self::P_1080 => [
+                'width' => 1080,
+                'height' => 1920,
+            ],
+            self::P_1440 => [
+                'width' => 1440,
+                'height' => 2560,
+            ],
+
+            // iPhone models
+            self::IPHONE_SE, self::IPHONE_8 => [
+                'width' => 375,
+                'height' => 667,
+            ],
+            self::IPHONE_12, self::IPHONE_13, self::IPHONE_14 => [
+                'width' => 390,
+                'height' => 844,
+            ],
+            self::IPHONE_14_PLUS => [
+                'width' => 428,
+                'height' => 926,
+            ],
+            self::IPHONE_14_PRO, self::IPHONE_15 => [
+                'width' => 393,
+                'height' => 852,
+            ],
+            self::IPHONE_14_PRO_MAX, self::IPHONE_15_PRO_MAX => [
+                'width' => 430,
+                'height' => 932,
+            ],
+
+            // Android devices
+            self::PIXEL_5 => [
+                'width' => 393,
+                'height' => 851,
+            ],
+            self::PIXEL_6, self::PIXEL_7, self::PIXEL_7_PRO => [
+                'width' => 412,
+                'height' => 915,
+            ],
+            self::GALAXY_S21, self::GALAXY_S22 => [
+                'width' => 360,
+                'height' => 800,
+            ],
+            self::GALAXY_S23 => [
+                'width' => 360,
+                'height' => 780,
+            ],
+
+            // Tablets
+            self::IPAD => [
+                'width' => 768,
+                'height' => 1024,
+            ],
+            self::IPAD_PRO_11 => [
+                'width' => 834,
+                'height' => 1194,
+            ],
+            self::IPAD_PRO_129 => [
+                'width' => 1024,
+                'height' => 1366,
+            ],
+
+            // Web breakpoints
+            self::MOBILE_SM => [
+                'width' => 320,
+                'height' => 568,
+            ],
+            self::MOBILE_MD => [
+                'width' => 375,
+                'height' => 667,
+            ],
+            self::MOBILE_LG => [
+                'width' => 414,
+                'height' => 896,
+            ],
+            self::TABLET => [
+                'width' => 768,
+                'height' => 1024,
+            ],
+            self::DESKTOP_SM => [
+                'width' => 1024,
+                'height' => 768,
+            ],
+            self::DESKTOP_MD => [
+                'width' => 1366,
+                'height' => 768,
+            ],
+            self::DESKTOP_LG => [
+                'width' => 1920,
+                'height' => 1080,
+            ],
+            self::DESKTOP_XL => [
+                'width' => 2560,
+                'height' => 1440,
+            ],
+        };
+    }
+
+    public function getFormFactor(): string
+    {
+        $dimensions = $this->getDimensions();
+        return $dimensions['width'] > $dimensions['height'] ? 'wide' : 'narrow';
+    }
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::HD => 'HD (1280×720)',
+            self::FULL_HD => 'Full HD (1920×1080)',
+            self::QHD => '2K/QHD (2560×1440)',
+            self::UHD => '4K/UHD (3840×2160)',
+            self::UHD_8K => '8K (7680×4320)',
+
+            self::P_480 => '480p Portrait (640×480)',
+            self::P_720 => '720p Portrait (720×1280)',
+            self::P_1080 => '1080p Portrait (1080×1920)',
+            self::P_1440 => '1440p Portrait (1440×2560)',
+
+            self::IPHONE_SE => 'iPhone SE (375×667)',
+            self::IPHONE_8 => 'iPhone 8 (375×667)',
+            self::IPHONE_12 => 'iPhone 12 (390×844)',
+            self::IPHONE_13 => 'iPhone 13 (390×844)',
+            self::IPHONE_14 => 'iPhone 14 (390×844)',
+            self::IPHONE_14_PLUS => 'iPhone 14 Plus (428×926)',
+            self::IPHONE_14_PRO => 'iPhone 14 Pro (393×852)',
+            self::IPHONE_14_PRO_MAX => 'iPhone 14 Pro Max (430×932)',
+            self::IPHONE_15 => 'iPhone 15 (393×852)',
+            self::IPHONE_15_PRO_MAX => 'iPhone 15 Pro Max (430×932)',
+
+            self::PIXEL_5 => 'Google Pixel 5 (393×851)',
+            self::PIXEL_6 => 'Google Pixel 6 (412×915)',
+            self::PIXEL_7 => 'Google Pixel 7 (412×915)',
+            self::PIXEL_7_PRO => 'Google Pixel 7 Pro (412×915)',
+            self::GALAXY_S21 => 'Samsung Galaxy S21 (360×800)',
+            self::GALAXY_S22 => 'Samsung Galaxy S22 (360×800)',
+            self::GALAXY_S23 => 'Samsung Galaxy S23 (360×780)',
+
+            self::IPAD => 'iPad (768×1024)',
+            self::IPAD_PRO_11 => 'iPad Pro 11" (834×1194)',
+            self::IPAD_PRO_129 => 'iPad Pro 12.9" (1024×1366)',
+
+            self::MOBILE_SM => 'Mobile Small (320×568)',
+            self::MOBILE_MD => 'Mobile Medium (375×667)',
+            self::MOBILE_LG => 'Mobile Large (414×896)',
+            self::TABLET => 'Tablet (768×1024)',
+            self::DESKTOP_SM => 'Desktop Small (1024×768)',
+            self::DESKTOP_MD => 'Desktop Medium (1366×768)',
+            self::DESKTOP_LG => 'Desktop Large (1920×1080)',
+            self::DESKTOP_XL => 'Desktop XL (2560×1440)',
+        };
+    }
+
+    public static function fromString(string $value): ?self
+    {
+        return self::tryFrom($value);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public static function getAllProfileNames(): array
+    {
+        return array_map(static fn (self $size) => $size->value, self::cases());
+    }
+
+    public static function getSuggestion(string $invalid): ?string
+    {
+        $all = self::getAllProfileNames();
+        $shortest = null;
+        $shortestDistance = PHP_INT_MAX;
+
+        foreach ($all as $profile) {
+            $distance = levenshtein($invalid, $profile);
+            if ($distance < $shortestDistance) {
+                $shortestDistance = $distance;
+                $shortest = $profile;
+            }
+        }
+
+        return $shortestDistance <= 3 ? $shortest : null;
+    }
+}

--- a/src/Event/PreManifestCompileEvent.php
+++ b/src/Event/PreManifestCompileEvent.php
@@ -10,6 +10,7 @@ class PreManifestCompileEvent
 {
     public function __construct(
         public Manifest $manifest,
+        public readonly null|string $locale = null,
     ) {
     }
 }

--- a/src/EventListener/ManifestScreenshotListener.php
+++ b/src/EventListener/ManifestScreenshotListener.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\EventListener;
+
+use function glob;
+use function pathinfo;
+use const PATHINFO_FILENAME;
+use function preg_match;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use SpomkyLabs\PwaBundle\Dto\Asset;
+use SpomkyLabs\PwaBundle\Dto\Screenshot;
+use SpomkyLabs\PwaBundle\Event\PreManifestCompileEvent;
+use SpomkyLabs\PwaBundle\Service\CanLogInterface;
+use SpomkyLabs\PwaBundle\Service\ScreenshotAttributeCollector;
+use function sprintf;
+use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+#[AsEventListener(event: PreManifestCompileEvent::class, priority: -100)]
+final class ManifestScreenshotListener implements CanLogInterface
+{
+    private LoggerInterface $logger;
+
+    public function __construct(
+        private readonly ScreenshotAttributeCollector $attributeCollector,
+        private readonly RouterInterface $router,
+        private readonly AssetMapperInterface $assetMapper,
+    ) {
+        $this->logger = new NullLogger();
+    }
+
+    public function __invoke(PreManifestCompileEvent $event): void
+    {
+        ['configurations' => $configurations] = $this->attributeCollector->collect($event->locale);
+
+        $missingScreenshots = [];
+        $wideScreenshots = [];
+        $narrowScreenshots = [];
+
+        foreach ($configurations as $config) {
+            // Find all screenshot files matching this configuration
+            $pattern = sprintf('%s%s-*x*.%s', $config->output, $config->filename, $config->format);
+            $files = glob($pattern) ?: [];
+
+            if ($files === []) {
+                $missingScreenshots[] = $pattern;
+                continue;
+            }
+
+            foreach ($files as $filename) {
+                // Extract dimensions from filename (e.g., "homepage-fr-1920x941.webp")
+                $basename = pathinfo($filename, PATHINFO_FILENAME);
+                if (! preg_match('/-(\d+)x(\d+)$/', $basename, $matches)) {
+                    continue;
+                }
+
+                $width = (int) $matches[1];
+                $height = (int) $matches[2];
+
+                $screenshot = new Screenshot();
+
+                // Try to get asset from AssetMapper, fallback to filename
+                $asset = $this->assetMapper->getAssetFromSourcePath($filename);
+                $screenshot->src = new Asset(src: $asset === null ? $filename : $asset->logicalPath);
+
+                $screenshot->width = $width;
+                $screenshot->height = $height;
+                $screenshot->formFactor = $width > $height ? 'wide' : 'narrow';
+                $screenshot->locale = $config->locale;
+                $screenshot->type = 'image/' . $config->format;
+
+                if ($config->platform !== null) {
+                    $screenshot->platform = $config->platform;
+                }
+
+                if ($config->label !== null) {
+                    $screenshot->label = $config->label;
+                }
+
+                // Generate the reference URL from the route
+                if ($config->route !== null) {
+                    $screenshot->reference = $this->router->generate(
+                        $config->route,
+                        $config->routeParameters,
+                        UrlGeneratorInterface::ABSOLUTE_URL
+                    );
+                } elseif ($config->url !== null) {
+                    $screenshot->reference = $config->url;
+                }
+
+                // Group by form factor
+                if ($screenshot->formFactor === 'wide') {
+                    $wideScreenshots[] = $screenshot;
+                } else {
+                    $narrowScreenshots[] = $screenshot;
+                }
+            }
+        }
+
+        // Add wide screenshots first, then narrow
+        foreach ($wideScreenshots as $screenshot) {
+            $event->manifest->screenshots[] = $screenshot;
+        }
+        foreach ($narrowScreenshots as $screenshot) {
+            $event->manifest->screenshots[] = $screenshot;
+        }
+
+        if ($missingScreenshots !== []) {
+            $this->logger->warning(
+                'Missing screenshots. Run "bin/console pwa:create:screenshot --from-attributes" to generate them.',
+                [
+                    'missing' => $missingScreenshots,
+                ]
+            );
+        }
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+}

--- a/src/EventListener/ScreenshotListener.php
+++ b/src/EventListener/ScreenshotListener.php
@@ -42,7 +42,7 @@ final class ScreenshotListener implements CanLogInterface
         $this->logger->debug('User agent found.', [
             'user_agent' => $userAgent,
         ]);
-        $userAgentToFind = $this->userAgent ?? 'HeadlessChrome';
+        $userAgentToFind = $this->userAgent ?? 'PWAScreenshotBot';
         if (! str_contains($userAgent, $userAgentToFind)) {
             $this->logger->debug('User agent does not match.', [
                 'user_agent' => $userAgent,

--- a/src/Normalizer/ScreenshotNormalizer.php
+++ b/src/Normalizer/ScreenshotNormalizer.php
@@ -26,7 +26,7 @@ final class ScreenshotNormalizer implements NormalizerInterface, NormalizerAware
     }
 
     /**
-     * @return array{src: string, sizes?: string, form_factor?: string, label?: string, platform?: string, format?: string}
+     * @return array{src: string, sizes?: string, form_factor?: string, label?: string, platform?: string, type?: string}
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
@@ -43,9 +43,9 @@ final class ScreenshotNormalizer implements NormalizerInterface, NormalizerAware
             'src' => $this->normalizer->normalize($data->src, $format, $context),
             'sizes' => $sizes,
             'form_factor' => $formFactor,
-            'label' => $data->label,
+            'label' => $this->normalizer->normalize($data->getLabel(), $format, $context),
             'platform' => $data->platform,
-            'format' => $imageType,
+            'type' => $imageType,
         ];
 
         $cleanup = static fn (array $data): array => array_filter(
@@ -78,7 +78,7 @@ final class ScreenshotNormalizer implements NormalizerInterface, NormalizerAware
         if ($object->width !== null && $object->height !== null) {
             return [
                 'sizes' => sprintf('%dx%d', $object->width, $object->height),
-                'formFactor' => $object->formFactor ?? $this->getFormFactor($object->width, $object->height),
+                'formFactor' => $object->formFactor,
             ];
         }
 
@@ -89,13 +89,19 @@ final class ScreenshotNormalizer implements NormalizerInterface, NormalizerAware
             ];
         }
 
-        ['width' => $width, 'height' => $height] = $this->imageProcessor->getSizes(
-            file_get_contents($asset->sourcePath)
-        );
+        $imageData = @file_get_contents($asset->sourcePath);
+        if ($imageData === false) {
+            return [
+                'sizes' => null,
+                'formFactor' => $object->formFactor,
+            ];
+        }
+
+        ['width' => $width, 'height' => $height] = $this->imageProcessor->getSizes($imageData);
 
         return [
             'sizes' => sprintf('%dx%d', $width, $height),
-            'formFactor' => $object->formFactor ?? $this->getFormFactor($width, $height),
+            'formFactor' => $object->formFactor,
         ];
     }
 
@@ -106,14 +112,5 @@ final class ScreenshotNormalizer implements NormalizerInterface, NormalizerAware
         }
 
         return MimeTypes::getDefault()->guessMimeType($asset->sourcePath);
-    }
-
-    private function getFormFactor(?int $width, ?int $height): ?string
-    {
-        if ($width === null || $height === null) {
-            return null;
-        }
-
-        return $width > $height ? 'wide' : 'narrow';
     }
 }

--- a/src/Resources/config/definition/web_client.php
+++ b/src/Resources/config/definition/web_client.php
@@ -12,9 +12,9 @@ return static function (DefinitionConfigurator $definition): void {
         ->info('The Panther Client for generating screenshots. If not set, the default client will be used.')
         ->end()
         ->scalarNode('user_agent')
-        ->defaultNull()
+        ->defaultValue('PWAScreenshotBot')
         ->info(
-            'The user agent to use when generating screenshots. If not set, the default user agent will be used. When requesting the current application in an environment other than "prod", the profiler will be disabled.'
+            'The user agent to use when generating screenshots. When this user agent is detected, the Symfony profiler and debug toolbar will be automatically disabled to ensure screenshots look like production.'
         )
         ->end()
         ->end();

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -13,10 +13,9 @@ use SpomkyLabs\PwaBundle\Command\CreateScreenshotCommand;
 use SpomkyLabs\PwaBundle\Command\ListCacheStrategiesCommand;
 use SpomkyLabs\PwaBundle\CompilerPass\LoggerCompilerPass;
 use SpomkyLabs\PwaBundle\DataCollector\PwaCollector;
-use SpomkyLabs\PwaBundle\EventListener\EarlyHintsListener;
 use SpomkyLabs\PwaBundle\EventListener\FileCompileEventListener;
+use SpomkyLabs\PwaBundle\EventListener\ManifestScreenshotListener;
 use SpomkyLabs\PwaBundle\EventListener\PwaDevServerListener;
-use SpomkyLabs\PwaBundle\EventListener\ResourceHintsListener;
 use SpomkyLabs\PwaBundle\EventListener\ScreenshotListener;
 use SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor;
 use SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor;
@@ -31,6 +30,9 @@ use SpomkyLabs\PwaBundle\Service\IconResolver;
 use SpomkyLabs\PwaBundle\Service\ManifestBuilder;
 use SpomkyLabs\PwaBundle\Service\ManifestCompiler;
 use SpomkyLabs\PwaBundle\Service\ResourceHintsBuilder;
+use SpomkyLabs\PwaBundle\Service\ScreenshotAttributeCollector;
+use SpomkyLabs\PwaBundle\Service\ScreenshotGenerator;
+use SpomkyLabs\PwaBundle\Service\ScreenshotUrlGenerator;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerCompiler;
 use SpomkyLabs\PwaBundle\Service\SpeculationRulesBuilder;
@@ -73,6 +75,8 @@ return static function (ContainerConfigurator $configurator): void {
 
     $container->set(IconResolver::class);
     $container->set(ApplicationIconCompiler::class);
+    $container->set(ScreenshotUrlGenerator::class);
+    $container->set(ScreenshotAttributeCollector::class);
 
     /*** Service Worker ***/
     $container->set(ServiceWorkerBuilder::class)
@@ -101,6 +105,7 @@ return static function (ContainerConfigurator $configurator): void {
     $container->set(CompileCommand::class);
     if (class_exists(Client::class) && class_exists(WebDriverDimension::class) && class_exists(MimeTypes::class)) {
         $container->set(CreateScreenshotCommand::class);
+        $container->set(ScreenshotGenerator::class);
     }
     if (class_exists(MimeTypes::class)) {
         $container->set(CreateIconsCommand::class);
@@ -131,13 +136,7 @@ return static function (ContainerConfigurator $configurator): void {
     /*** Event Listeners and Subscribers ***/
     $container->set(FileCompiler::class);
     $container->set(FileCompileEventListener::class);
-    $container->set(EarlyHintsListener::class)
-        ->args([
-            '$config' => param('spomky_labs_pwa.early_hints.config'),
-            '$manifestPublicUrl' => param('spomky_labs_pwa.manifest.public_url'),
-        ])
-    ;
-    $container->set(ResourceHintsListener::class);
+    $container->set(ManifestScreenshotListener::class);
     $container->set(PwaDevServerListener::class)
         ->args([
             '$profiler' => service('profiler')
@@ -176,9 +175,8 @@ return static function (ContainerConfigurator $configurator): void {
         ->tag('spomky_labs_pwa.preload_urls_generator')
     ;
 
-    $container->set(ScreenshotListener::class);
-
     if ($configurator->env() !== 'prod') {
+        $container->set(ScreenshotListener::class);
         $container->set(PwaCollector::class)
             ->tag('data_collector', [
                 'template' => '@SpomkyLabsPwa/Collector/template.html.twig',

--- a/src/Service/ManifestCompiler.php
+++ b/src/Service/ManifestCompiler.php
@@ -114,7 +114,7 @@ final class ManifestCompiler implements FileCompilerInterface, CanLogInterface
         }
 
         $callback = function () use ($manifest, $locale): string {
-            $preEvent = new PreManifestCompileEvent($manifest);
+            $preEvent = new PreManifestCompileEvent($manifest, $locale);
             $preEvent = $this->dispatcher->dispatch($preEvent);
             assert($preEvent instanceof PreManifestCompileEvent);
 

--- a/src/Service/ScreenshotAttributeCollector.php
+++ b/src/Service/ScreenshotAttributeCollector.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Service;
+
+use function class_exists;
+use function is_string;
+use ReflectionAttribute;
+use ReflectionClass;
+use SpomkyLabs\PwaBundle\Attribute\Screenshot as ScreenshotAttribute;
+use SpomkyLabs\PwaBundle\Dto\ScreenshotConfiguration;
+use function sprintf;
+use function str_contains;
+use function str_replace;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Routing\RouterInterface;
+use Throwable;
+
+readonly class ScreenshotAttributeCollector
+{
+    public function __construct(
+        #[Autowire(param: 'kernel.project_dir')]
+        private string $projectDir,
+        private RouterInterface $router,
+    ) {
+    }
+
+    /**
+     * Collect all screenshot configurations from #[Screenshot] attributes.
+     *
+     * @param null|string $filterLocale If set, only return configurations for this locale
+     * @return array{configurations: array<ScreenshotConfiguration>}
+     */
+    public function collect(null|string $filterLocale = null): array
+    {
+        $configurations = [];
+        $defaultOutput = sprintf('%s/assets/screenshots/', $this->projectDir);
+        $routeCollection = $this->router->getRouteCollection();
+
+        foreach ($routeCollection as $routeName => $route) {
+            $controller = $route->getDefault('_controller');
+            if ($controller === null || ! is_string($controller)) {
+                continue;
+            }
+
+            // Parse controller string (e.g., "App\Controller\HomeController::index" or invokable)
+            if (str_contains($controller, '::')) {
+                [$className, $methodName] = explode('::', $controller, 2);
+            } else {
+                $className = $controller;
+                $methodName = '__invoke';
+            }
+
+            if (! class_exists($className)) {
+                continue;
+            }
+
+            try {
+                $reflectionClass = new ReflectionClass($className);
+                if (! $reflectionClass->hasMethod($methodName)) {
+                    continue;
+                }
+
+                $reflectionMethod = $reflectionClass->getMethod($methodName);
+                $attributes = $reflectionMethod->getAttributes(
+                    ScreenshotAttribute::class,
+                    ReflectionAttribute::IS_INSTANCEOF
+                );
+
+                foreach ($attributes as $attribute) {
+                    /** @var ScreenshotAttribute $screenshotAttr */
+                    $screenshotAttr = $attribute->newInstance();
+
+                    $localesToProcess = $screenshotAttr->locales !== [] ? $screenshotAttr->locales : [null];
+
+                    foreach ($localesToProcess as $locale) {
+                        // Filter by locale if requested
+                        if ($filterLocale !== null && $locale !== null && $locale !== $filterLocale) {
+                            continue;
+                        }
+
+                        $config = $this->buildConfiguration($screenshotAttr, $routeName, $locale, $defaultOutput);
+
+                        if ($config !== null) {
+                            $configurations[] = $config;
+                        }
+                    }
+                }
+            } catch (Throwable) {
+                continue;
+            }
+        }
+
+        return [
+            'configurations' => $configurations,
+        ];
+    }
+
+    /**
+     * Build a ScreenshotConfiguration from an attribute.
+     */
+    public function buildConfiguration(
+        ScreenshotAttribute $attr,
+        string $routeName,
+        null|string $locale,
+        null|string $defaultOutput = null
+    ): null|ScreenshotConfiguration {
+        $defaultOutput ??= sprintf('%s/assets/screenshots/', $this->projectDir);
+
+        $parameters = $attr->parameters;
+        if ($locale !== null) {
+            $parameters['_locale'] = $locale;
+        }
+
+        $baseFilename = $attr->name ?? str_replace('.', '-', $routeName);
+        $filename = $locale !== null ? sprintf('%s-%s', $baseFilename, $locale) : $baseFilename;
+
+        $configData = [
+            'route' => $routeName,
+            'parameters' => $parameters,
+            'sizes' => $attr->sizes,
+            'filename' => $filename,
+            'output' => $attr->output ?? $defaultOutput,
+            'locale' => $locale,
+            'label' => $attr->label,
+            'format' => $attr->format ?? 'png',
+        ];
+
+        if ($attr->platform !== null) {
+            $configData['platform'] = $attr->platform;
+        }
+
+        try {
+            return ScreenshotConfiguration::fromArray($configData, $defaultOutput);
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    public function getDefaultOutput(): string
+    {
+        return sprintf('%s/assets/screenshots/', $this->projectDir);
+    }
+}

--- a/src/Service/ScreenshotGenerator.php
+++ b/src/Service/ScreenshotGenerator.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Service;
+
+use function assert;
+use function count;
+use Facebook\WebDriver\WebDriverDimension;
+use function function_exists;
+use function is_string;
+use SpomkyLabs\PwaBundle\Dto\ScreenshotConfiguration;
+use SpomkyLabs\PwaBundle\ImageProcessor\Configuration;
+use SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface;
+use function sprintf;
+use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Mime\MimeTypes;
+use Symfony\Component\Panther\Client;
+use Throwable;
+
+final readonly class ScreenshotGenerator
+{
+    public function __construct(
+        private AssetMapperInterface $assetMapper,
+        private Filesystem $filesystem,
+        private null|ImageProcessorInterface $imageProcessor,
+        private ScreenshotAttributeCollector $attributeCollector,
+        private ScreenshotUrlGenerator $urlGenerator,
+        #[Autowire('@pwa.web_client')]
+        private null|Client $webClient = null,
+        #[Autowire(param: 'spomky_labs_pwa.screenshot_user_agent')]
+        private null|string $userAgent = null,
+    ) {
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->imageProcessor !== null;
+    }
+
+    public function generate(SymfonyStyle $io): bool
+    {
+        if ($this->imageProcessor === null) {
+            $io->error('The image processor is not enabled.');
+            return false;
+        }
+
+        // Load configurations from #[Screenshot] attributes
+        ['configurations' => $configurations] = $this->attributeCollector->collect();
+        if ($configurations === []) {
+            $io->warning('No #[Screenshot] attributes found on controller methods.');
+            return true; // Not an error, just nothing to do
+        }
+
+        // Validate all configurations
+        foreach ($configurations as $index => $config) {
+            $error = $config->validate();
+            if ($error !== null) {
+                $io->error(sprintf('Configuration #%d: %s', $index + 1, $error));
+                return false;
+            }
+        }
+
+        // Count total screenshots to generate
+        $totalScreenshots = 0;
+        foreach ($configurations as $config) {
+            $totalScreenshots += count($config->sizes);
+        }
+
+        // Process all screenshots
+        $results = [];
+        $client = $this->getClient();
+        $currentIndex = 0;
+
+        foreach ($configurations as $configIndex => $config) {
+            // Generate URL from config (either direct URL or route)
+            $url = $this->urlGenerator->generateUrl($config);
+
+            $io->section(sprintf(
+                'URL %d/%d: %s (%d size(s))',
+                $configIndex + 1,
+                count($configurations),
+                $url,
+                count($config->sizes)
+            ));
+
+            foreach ($config->getExpandedSizes() as $sizeData) {
+                $currentIndex++;
+                $io->text(sprintf(
+                    '  [%d/%d] %s...',
+                    $currentIndex,
+                    $totalScreenshots,
+                    $sizeData['size']->getLabel()
+                ));
+
+                try {
+                    $result = $this->processScreenshot(
+                        $client,
+                        $url,
+                        $config,
+                        $sizeData['width'],
+                        $sizeData['height'],
+                        $sizeData['formFactor']
+                    );
+                    $results[] = $result;
+                    $io->success(sprintf('  Saved: %s', basename($result['filename'])));
+                } catch (Throwable $e) {
+                    $io->error(sprintf('  Failed: %s', $e->getMessage()));
+                    if (! $io->confirm('Continue with remaining screenshots?')) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        // Display final summary
+        $io->newLine();
+        $io->success(sprintf('%d screenshot(s) generated successfully.', count($results)));
+
+        return true;
+    }
+
+    /**
+     * @return array{filename: string, config: array<string, mixed>}
+     */
+    private function processScreenshot(
+        Client $client,
+        string $url,
+        ScreenshotConfiguration $config,
+        int $width,
+        int $height,
+        string $formFactor
+    ): array {
+        // Ensure output directory exists
+        if (! $this->filesystem->exists($config->output)) {
+            $this->filesystem->mkdir($config->output);
+        }
+
+        $tmpName = $this->filesystem->tempnam('', 'pwa-');
+
+        try {
+            $crawler = $client->request('GET', $url);
+
+            // Set window size
+            $client->manage()
+                ->window()
+                ->setSize(new WebDriverDimension($width, $height));
+
+            // Force minimum height to match viewport to ensure consistent dimensions
+            $client->executeScript(sprintf(
+                'document.documentElement.style.minHeight = "%dpx"; document.body.style.minHeight = "%dpx";',
+                $height,
+                $height
+            ));
+
+            $client->takeScreenshot($tmpName);
+
+            // Extract title from the page
+            $title = null;
+            try {
+                $titleElement = $crawler->filter('title');
+                if ($titleElement->count() > 0) {
+                    $title = $titleElement->text();
+                }
+            } catch (Throwable) {
+                // Title extraction failed, continue without it
+            }
+
+            // Process the screenshot - convert to target format
+            $data = file_get_contents($tmpName);
+            assert(is_string($data));
+            $configuration = Configuration::create($width, $height, $config->format);
+            $data = $this->imageProcessor->process($data, null, null, null, $configuration);
+            file_put_contents($tmpName, $data);
+
+            $filename = sprintf(
+                '%s/%s-%dx%d.%s',
+                $config->output,
+                $config->filename,
+                $width,
+                $height,
+                $config->format
+            );
+
+            $this->filesystem->copy($tmpName, $filename, true);
+            $this->filesystem->remove($tmpName);
+            $asset = $this->assetMapper->getAssetFromSourcePath($filename);
+            $outputMimeType = MimeTypes::getDefault()->guessMimeType($filename);
+
+            $resultConfig = [
+                'src' => $asset === null ? $filename : $asset->logicalPath,
+                'width' => $width,
+                'height' => $height,
+                'reference' => $url,
+            ];
+            if ($outputMimeType !== null) {
+                $resultConfig['type'] = $outputMimeType;
+            }
+            if ($title !== null) {
+                $resultConfig['label'] = $title;
+            }
+            $resultConfig['form_factor'] = $formFactor;
+            if ($config->platform !== null) {
+                $resultConfig['platform'] = $config->platform;
+            }
+
+            return [
+                'filename' => $filename,
+                'config' => $resultConfig,
+            ];
+        } catch (Throwable $e) {
+            // Clean up temporary file on error
+            if ($this->filesystem->exists($tmpName)) {
+                $this->filesystem->remove($tmpName);
+            }
+            throw $e;
+        }
+    }
+
+    private function getAvailablePort(): int
+    {
+        // If sockets extension is not available, use a random high port
+        if (! function_exists('socket_create_listen')) {
+            return random_int(9000, 9999);
+        }
+
+        $socket = socket_create_listen(0);
+        assert($socket !== false, 'Unable to create a socket.');
+        socket_getsockname($socket, $address, $port);
+        socket_close($socket);
+
+        return $port;
+    }
+
+    private function getDefaultArguments(): array
+    {
+        $args = [];
+        $headless = ! ($_SERVER['PANTHER_NO_HEADLESS'] ?? false);
+
+        if ($headless) {
+            $args[] = '--headless';
+            $args[] = '--window-size=1200,1100';
+            $args[] = '--disable-gpu';
+        }
+
+        // Only open devtools if not in headless mode
+        if (! $headless && ($_SERVER['PANTHER_DEVTOOLS'] ?? false)) {
+            $args[] = '--auto-open-devtools-for-tabs';
+        }
+
+        if ($_SERVER['PANTHER_NO_SANDBOX'] ?? $_SERVER['HAS_JOSH_K_SEAL_OF_APPROVAL'] ?? false) {
+            $args[] = '--no-sandbox';
+        }
+
+        // Hide scrollbars in screenshots
+        $args[] = '--hide-scrollbars';
+
+        if ($_SERVER['PANTHER_CHROME_ARGUMENTS'] ?? false) {
+            $arguments = explode(' ', (string) $_SERVER['PANTHER_CHROME_ARGUMENTS']);
+            $args = array_merge($args, $arguments);
+        }
+
+        return $args;
+    }
+
+    private function getClient(): Client
+    {
+        if ($this->webClient !== null) {
+            return clone $this->webClient;
+        }
+        $options = [
+            'port' => $this->getAvailablePort(),
+            'capabilities' => [
+                'acceptInsecureCerts' => true,
+            ],
+        ];
+        $arguments = $this->getDefaultArguments();
+        if ($this->userAgent !== null) {
+            $arguments[] = sprintf('--user-agent=%s', $this->userAgent);
+        }
+
+        // Allow specifying chromedriver binary via environment variable
+        $chromeDriverBinary = $_SERVER['PANTHER_CHROME_DRIVER_BINARY'] ?? $_ENV['PANTHER_CHROME_DRIVER_BINARY'] ?? null;
+
+        return Client::createChromeClient($chromeDriverBinary, $arguments, $options);
+    }
+}

--- a/src/Service/ScreenshotUrlGenerator.php
+++ b/src/Service/ScreenshotUrlGenerator.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Service;
+
+use SpomkyLabs\PwaBundle\Dto\ScreenshotConfiguration;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final readonly class ScreenshotUrlGenerator
+{
+    public function __construct(
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    /**
+     * Generate the URL from a configuration.
+     * If the configuration uses a route, it will be generated using the Symfony router.
+     * If the configuration uses a URL, it will be returned as-is.
+     */
+    public function generateUrl(ScreenshotConfiguration $config): string
+    {
+        // If it's a route, generate the URL
+        if ($config->isRoute()) {
+            return $this->urlGenerator->generate(
+                $config->route,
+                $config->routeParameters,
+                UrlGeneratorInterface::ABSOLUTE_URL
+            );
+        }
+
+        // Otherwise, return the URL as-is
+        return $config->url;
+    }
+}

--- a/tests/Unit/Attribute/ScreenshotTest.php
+++ b/tests/Unit/Attribute/ScreenshotTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Unit\Attribute;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\PwaBundle\Attribute\Screenshot;
+
+/**
+ * @internal
+ */
+final class ScreenshotTest extends TestCase
+{
+    #[Test]
+    public function itCanBeInstantiatedWithMinimalParameters(): void
+    {
+        $screenshot = new Screenshot(sizes: ['fhd', 'iphone-14']);
+
+        static::assertSame(['fhd', 'iphone-14'], $screenshot->sizes);
+        static::assertSame([], $screenshot->parameters);
+        static::assertNull($screenshot->name);
+        static::assertNull($screenshot->label);
+        static::assertNull($screenshot->platform);
+        static::assertNull($screenshot->output);
+        static::assertNull($screenshot->format);
+    }
+
+    #[Test]
+    public function itCanBeInstantiatedWithAllParameters(): void
+    {
+        $screenshot = new Screenshot(
+            sizes: ['fhd', 'ipad/LP', '1920x1080'],
+            parameters: [
+                '_locale' => 'fr',
+                'id' => 42,
+            ],
+            name: 'homepage',
+            label: 'Application homepage',
+            platform: 'windows',
+            output: '/custom/output',
+            format: 'webp'
+        );
+
+        static::assertSame(['fhd', 'ipad/LP', '1920x1080'], $screenshot->sizes);
+        static::assertSame([
+            '_locale' => 'fr',
+            'id' => 42,
+        ], $screenshot->parameters);
+        static::assertSame('homepage', $screenshot->name);
+        static::assertSame('Application homepage', $screenshot->label);
+        static::assertSame('windows', $screenshot->platform);
+        static::assertSame('/custom/output', $screenshot->output);
+        static::assertSame('webp', $screenshot->format);
+    }
+
+    #[Test]
+    public function itSupportsOrientationSelectorsInSizes(): void
+    {
+        $screenshot = new Screenshot(sizes: ['ipad/L', 'iphone-14/P', 'fhd/LP']);
+
+        static::assertContains('ipad/L', $screenshot->sizes);
+        static::assertContains('iphone-14/P', $screenshot->sizes);
+        static::assertContains('fhd/LP', $screenshot->sizes);
+    }
+
+    #[Test]
+    public function itSupportsRouteParameters(): void
+    {
+        $screenshot = new Screenshot(
+            sizes: ['desktop-lg'],
+            parameters: [
+                '_locale' => 'en',
+                'category' => 'tech',
+            ]
+        );
+
+        static::assertArrayHasKey('_locale', $screenshot->parameters);
+        static::assertArrayHasKey('category', $screenshot->parameters);
+        static::assertSame('en', $screenshot->parameters['_locale']);
+        static::assertSame('tech', $screenshot->parameters['category']);
+    }
+
+    #[Test]
+    public function itHasEmptyParametersByDefault(): void
+    {
+        $screenshot = new Screenshot(sizes: ['fhd']);
+
+        static::assertIsArray($screenshot->parameters);
+        static::assertEmpty($screenshot->parameters);
+    }
+}

--- a/tests/Unit/Dto/ScreenshotDimensionTest.php
+++ b/tests/Unit/Dto/ScreenshotDimensionTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Unit\Dto;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\PwaBundle\Dto\ScreenshotDimension;
+
+/**
+ * @internal
+ */
+final class ScreenshotDimensionTest extends TestCase
+{
+    #[Test]
+    public function itExpandsProfileWithoutOrientationSelector(): void
+    {
+        $dimensions = ScreenshotDimension::expandFromString('ipad');
+
+        static::assertCount(1, $dimensions);
+        static::assertSame(768, $dimensions[0]->getDimensions()['width']);
+        static::assertSame(1024, $dimensions[0]->getDimensions()['height']);
+    }
+
+    #[Test]
+    public function itExpandsProfileWithLandscapeSelector(): void
+    {
+        $dimensions = ScreenshotDimension::expandFromString('ipad/L');
+
+        static::assertCount(1, $dimensions);
+        static::assertSame(1024, $dimensions[0]->getDimensions()['width']);
+        static::assertSame(768, $dimensions[0]->getDimensions()['height']);
+        static::assertStringContainsString('Landscape', $dimensions[0]->getLabel());
+    }
+
+    #[Test]
+    public function itExpandsProfileWithPortraitSelector(): void
+    {
+        $dimensions = ScreenshotDimension::expandFromString('ipad/P');
+
+        static::assertCount(1, $dimensions);
+        static::assertSame(768, $dimensions[0]->getDimensions()['width']);
+        static::assertSame(1024, $dimensions[0]->getDimensions()['height']);
+        static::assertStringContainsString('Portrait', $dimensions[0]->getLabel());
+    }
+
+    #[Test]
+    public function itExpandsProfileWithBothOrientationsSelector(): void
+    {
+        $dimensions = ScreenshotDimension::expandFromString('ipad/LP');
+
+        static::assertCount(2, $dimensions);
+
+        // First is portrait
+        static::assertSame(768, $dimensions[0]->getDimensions()['width']);
+        static::assertSame(1024, $dimensions[0]->getDimensions()['height']);
+        static::assertStringContainsString('Portrait', $dimensions[0]->getLabel());
+
+        // Second is landscape
+        static::assertSame(1024, $dimensions[1]->getDimensions()['width']);
+        static::assertSame(768, $dimensions[1]->getDimensions()['height']);
+        static::assertStringContainsString('Landscape', $dimensions[1]->getLabel());
+    }
+
+    #[Test]
+    public function itExpandsExplicitDimensionsWithoutOrientationSelector(): void
+    {
+        $dimensions = ScreenshotDimension::expandFromString('1920x1080');
+
+        static::assertCount(1, $dimensions);
+        static::assertSame(1920, $dimensions[0]->getDimensions()['width']);
+        static::assertSame(1080, $dimensions[0]->getDimensions()['height']);
+    }
+
+    #[Test]
+    public function itExpandsExplicitDimensionsWithLandscapeSelector(): void
+    {
+        $dimensions = ScreenshotDimension::expandFromString('1920x1080/L');
+
+        static::assertCount(1, $dimensions);
+        static::assertSame(1920, $dimensions[0]->getDimensions()['width']);
+        static::assertSame(1080, $dimensions[0]->getDimensions()['height']);
+    }
+
+    #[Test]
+    public function itExpandsExplicitDimensionsWithPortraitSelector(): void
+    {
+        $dimensions = ScreenshotDimension::expandFromString('1920x1080/P');
+
+        static::assertCount(1, $dimensions);
+        static::assertSame(1080, $dimensions[0]->getDimensions()['width']);
+        static::assertSame(1920, $dimensions[0]->getDimensions()['height']);
+    }
+
+    #[Test]
+    public function itExpandsExplicitDimensionsWithBothOrientationsSelector(): void
+    {
+        $dimensions = ScreenshotDimension::expandFromString('1920x1080/LP');
+
+        static::assertCount(2, $dimensions);
+
+        // First is portrait
+        static::assertSame(1080, $dimensions[0]->getDimensions()['width']);
+        static::assertSame(1920, $dimensions[0]->getDimensions()['height']);
+
+        // Second is landscape
+        static::assertSame(1920, $dimensions[1]->getDimensions()['width']);
+        static::assertSame(1080, $dimensions[1]->getDimensions()['height']);
+    }
+
+    #[Test]
+    public function itHandlesCaseInsensitiveOrientationSelectors(): void
+    {
+        $dimensions1 = ScreenshotDimension::expandFromString('ipad/l');
+        $dimensions2 = ScreenshotDimension::expandFromString('ipad/L');
+        $dimensions3 = ScreenshotDimension::expandFromString('ipad/lp');
+        $dimensions4 = ScreenshotDimension::expandFromString('ipad/LP');
+
+        static::assertCount(1, $dimensions1);
+        static::assertCount(1, $dimensions2);
+        static::assertCount(2, $dimensions3);
+        static::assertCount(2, $dimensions4);
+    }
+
+    #[Test]
+    public function itReturnsEmptyArrayForInvalidSize(): void
+    {
+        $dimensions = ScreenshotDimension::expandFromString('invalid-size');
+
+        static::assertCount(0, $dimensions);
+    }
+
+    #[Test]
+    public function itReturnsEmptyArrayForInvalidSizeWithOrientation(): void
+    {
+        $dimensions = ScreenshotDimension::expandFromString('invalid-size/LP');
+
+        static::assertCount(0, $dimensions);
+    }
+}

--- a/tests/Unit/EventListener/ManifestScreenshotListenerTest.php
+++ b/tests/Unit/EventListener/ManifestScreenshotListenerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Unit\EventListener;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\PwaBundle\Dto\Manifest;
+use SpomkyLabs\PwaBundle\Event\PreManifestCompileEvent;
+use SpomkyLabs\PwaBundle\EventListener\ManifestScreenshotListener;
+use SpomkyLabs\PwaBundle\Service\ScreenshotAttributeCollector;
+use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @internal
+ *
+ * Note: ManifestScreenshotListener now automatically discovers screenshots
+ * by detecting #[Screenshot] attributes on controller methods.
+ * Comprehensive testing of this behavior requires functional tests with
+ * real controllers and routes.
+ */
+final class ManifestScreenshotListenerTest extends TestCase
+{
+    #[Test]
+    public function itDoesNothingWhenNoConfigurationsExist(): void
+    {
+        $attributeCollector = $this->createMock(ScreenshotAttributeCollector::class);
+        $attributeCollector->method('collect')
+            ->willReturn([
+                'configurations' => [],
+            ]);
+
+        $router = $this->createMock(RouterInterface::class);
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+
+        $listener = new ManifestScreenshotListener($attributeCollector, $router, $assetMapper);
+
+        $manifest = new Manifest();
+        $event = new PreManifestCompileEvent($manifest);
+
+        $listener($event);
+
+        static::assertCount(0, $manifest->screenshots);
+    }
+
+    #[Test]
+    public function itDoesNothingWhenRoutesHaveNoScreenshotAttributes(): void
+    {
+        $attributeCollector = $this->createMock(ScreenshotAttributeCollector::class);
+        $attributeCollector->method('collect')
+            ->willReturn([
+                'configurations' => [],
+            ]);
+
+        $router = $this->createMock(RouterInterface::class);
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+
+        $listener = new ManifestScreenshotListener($attributeCollector, $router, $assetMapper);
+
+        $manifest = new Manifest();
+        $event = new PreManifestCompileEvent($manifest);
+
+        $listener($event);
+
+        // No screenshots should be added since the collector returns no configurations
+        static::assertCount(0, $manifest->screenshots);
+    }
+}

--- a/tests/Unit/EventListener/ScreenshotListenerTest.php
+++ b/tests/Unit/EventListener/ScreenshotListenerTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Unit\EventListener;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use SpomkyLabs\PwaBundle\EventListener\ScreenshotListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+
+/**
+ * @internal
+ */
+final class ScreenshotListenerTest extends TestCase
+{
+    #[Test]
+    public function itDoesNotDisableProfilerWhenNotMainRequest(): void
+    {
+        // Given
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects(static::never())
+            ->method('disable');
+
+        $listener = new ScreenshotListener($profiler, 'HeadlessChrome');
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = new Request();
+        $request->headers->set('user-agent', 'HeadlessChrome/1.0');
+
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::SUB_REQUEST);
+
+        // When
+        $listener->onRequest($event);
+
+        // Then - expectations are checked automatically
+    }
+
+    #[Test]
+    public function itDoesNotDisableProfilerWhenNoProfiler(): void
+    {
+        // Given
+        $listener = new ScreenshotListener(null, 'HeadlessChrome');
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = new Request();
+        $request->headers->set('user-agent', 'HeadlessChrome/1.0');
+
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        // When
+        $listener->onRequest($event);
+
+        // Then - should not throw exception
+        static::assertTrue(true); // No exception means test passed
+    }
+
+    #[Test]
+    public function itDoesNotDisableProfilerWhenNoUserAgent(): void
+    {
+        // Given
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects(static::never())
+            ->method('disable');
+
+        $listener = new ScreenshotListener($profiler, 'HeadlessChrome');
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = new Request();
+
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        // When
+        $listener->onRequest($event);
+
+        // Then - expectations are checked automatically
+    }
+
+    #[Test]
+    public function itDoesNotDisableProfilerWhenUserAgentDoesNotMatch(): void
+    {
+        // Given
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects(static::never())
+            ->method('disable');
+
+        $listener = new ScreenshotListener($profiler, 'HeadlessChrome');
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = new Request();
+        $request->headers->set('user-agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        // When
+        $listener->onRequest($event);
+
+        // Then - expectations are checked automatically
+    }
+
+    #[Test]
+    public function itDisablesProfilerWhenUserAgentMatches(): void
+    {
+        // Given
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects(static::once())
+            ->method('disable');
+
+        $listener = new ScreenshotListener($profiler, 'HeadlessChrome');
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = new Request();
+        $request->headers->set('user-agent', 'Mozilla/5.0 (X11; Linux x86_64) HeadlessChrome/1.0');
+
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        // When
+        $listener->onRequest($event);
+
+        // Then - expectations are checked automatically
+    }
+
+    #[Test]
+    public function itUsesDefaultUserAgentWhenNotProvided(): void
+    {
+        // Given
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects(static::once())
+            ->method('disable');
+
+        $listener = new ScreenshotListener($profiler);
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = new Request();
+        $request->headers->set('user-agent', 'PWAScreenshotBot/1.0');
+
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        // When
+        $listener->onRequest($event);
+
+        // Then - expectations are checked automatically
+    }
+
+    #[Test]
+    public function itCanSetLogger(): void
+    {
+        // Given
+        $listener = new ScreenshotListener(null, 'HeadlessChrome');
+        $logger = $this->createMock(LoggerInterface::class);
+
+        // When
+        $listener->setLogger($logger);
+
+        // Then
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = new Request();
+        $request->headers->set('user-agent', 'HeadlessChrome/1.0');
+
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        // Should not throw exception
+        $listener->onRequest($event);
+        static::assertTrue(true); // No exception means test passed
+    }
+
+    #[Test]
+    public function itLogsDebugMessages(): void
+    {
+        // Given
+        $profiler = $this->createMock(Profiler::class);
+        $listener = new ScreenshotListener($profiler, 'HeadlessChrome');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(static::atLeastOnce())
+            ->method('debug');
+
+        $listener->setLogger($logger);
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = new Request();
+        $request->headers->set('user-agent', 'HeadlessChrome/1.0');
+
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        // When
+        $listener->onRequest($event);
+
+        // Then - expectations are checked automatically
+    }
+}

--- a/tests/Unit/Normalizer/ScreenshotNormalizerTest.php
+++ b/tests/Unit/Normalizer/ScreenshotNormalizerTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Unit\Normalizer;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\PwaBundle\Dto\Asset;
+use SpomkyLabs\PwaBundle\Dto\Screenshot;
+use SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface;
+use SpomkyLabs\PwaBundle\Normalizer\ScreenshotNormalizer;
+use stdClass;
+use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @internal
+ */
+final class ScreenshotNormalizerTest extends TestCase
+{
+    #[Test]
+    public function itSupportsScreenshotNormalization(): void
+    {
+        // Given
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+        $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
+        $screenshot = new Screenshot();
+
+        // When
+        $supports = $normalizer->supportsNormalization($screenshot);
+
+        // Then
+        static::assertTrue($supports);
+    }
+
+    #[Test]
+    public function itDoesNotSupportOtherTypes(): void
+    {
+        // Given
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+        $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
+        $object = new stdClass();
+
+        // When
+        $supports = $normalizer->supportsNormalization($object);
+
+        // Then
+        static::assertFalse($supports);
+    }
+
+    #[Test]
+    public function itReturnsCorrectSupportedTypes(): void
+    {
+        // Given
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+        $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
+
+        // When
+        $supportedTypes = $normalizer->getSupportedTypes(null);
+
+        // Then
+        static::assertArrayHasKey(Screenshot::class, $supportedTypes);
+        static::assertTrue($supportedTypes[Screenshot::class]);
+    }
+
+    #[Test]
+    public function itNormalizesScreenshotWithWidthAndHeight(): void
+    {
+        // Given
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+
+        $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
+
+        $assetNormalizer = $this->createMock(NormalizerInterface::class);
+        $assetNormalizer->method('normalize')
+            ->willReturnCallback(static fn ($data): string => match (true) {
+                $data instanceof Asset => '/assets/screenshot.png',
+                default => 'Test Screenshot',
+            });
+        $normalizer->setNormalizer($assetNormalizer);
+
+        $screenshot = new Screenshot();
+        $screenshot->src = Asset::create('screenshot.png');
+        $screenshot->width = 1920;
+        $screenshot->height = 1080;
+        $screenshot->formFactor = 'wide';
+        $screenshot->label = 'Test Screenshot';
+        $screenshot->platform = 'android';
+
+        // When
+        $result = $normalizer->normalize($screenshot);
+
+        // Then
+        static::assertIsArray($result);
+        static::assertSame('/assets/screenshot.png', $result['src']);
+        static::assertSame('1920x1080', $result['sizes']);
+        static::assertSame('wide', $result['form_factor']);
+        static::assertSame('Test Screenshot', $result['label']);
+        static::assertSame('android', $result['platform']);
+        static::assertArrayNotHasKey('type', $result); // No type specified
+    }
+
+    #[Test]
+    public function itNormalizesScreenshotWithNarrowFormFactor(): void
+    {
+        // Given
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+
+        $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
+
+        $assetNormalizer = $this->createMock(NormalizerInterface::class);
+        $assetNormalizer->method('normalize')
+            ->willReturn('/assets/screenshot.png');
+        $normalizer->setNormalizer($assetNormalizer);
+
+        $screenshot = new Screenshot();
+        $screenshot->src = Asset::create('screenshot.png');
+        $screenshot->width = 390;
+        $screenshot->height = 844;
+        $screenshot->formFactor = 'narrow';
+
+        // When
+        $result = $normalizer->normalize($screenshot);
+
+        // Then
+        static::assertIsArray($result);
+        static::assertSame('390x844', $result['sizes']);
+        static::assertSame('narrow', $result['form_factor']);
+    }
+
+    #[Test]
+    public function itNormalizesScreenshotWithExplicitFormFactor(): void
+    {
+        // Given
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+
+        $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
+
+        $assetNormalizer = $this->createMock(NormalizerInterface::class);
+        $assetNormalizer->method('normalize')
+            ->willReturn('/assets/screenshot.png');
+        $normalizer->setNormalizer($assetNormalizer);
+
+        $screenshot = new Screenshot();
+        $screenshot->src = Asset::create('screenshot.png');
+        $screenshot->width = 1920;
+        $screenshot->height = 1080;
+        $screenshot->formFactor = 'narrow'; // Override auto-detection
+
+        // When
+        $result = $normalizer->normalize($screenshot);
+
+        // Then
+        static::assertIsArray($result);
+        static::assertSame('narrow', $result['form_factor']);
+    }
+
+    #[Test]
+    public function itNormalizesScreenshotWithoutDimensions(): void
+    {
+        // Given
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+
+        $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
+
+        $assetNormalizer = $this->createMock(NormalizerInterface::class);
+        $assetNormalizer->method('normalize')
+            ->willReturn('/screenshot.png');
+        $normalizer->setNormalizer($assetNormalizer);
+
+        $screenshot = new Screenshot();
+        $screenshot->src = Asset::create('/screenshot.png');
+        $screenshot->formFactor = 'wide';
+
+        // When
+        $result = $normalizer->normalize($screenshot);
+
+        // Then
+        static::assertIsArray($result);
+        static::assertArrayNotHasKey('sizes', $result);
+        static::assertSame('wide', $result['form_factor']);
+    }
+
+    #[Test]
+    public function itFiltersNullValuesFromResult(): void
+    {
+        // Given
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+
+        $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
+
+        $assetNormalizer = $this->createMock(NormalizerInterface::class);
+        $assetNormalizer->method('normalize')
+            ->willReturnCallback(static fn ($data): ?string => match (true) {
+                $data instanceof Asset => '/assets/screenshot.png',
+                default => null,
+            });
+        $normalizer->setNormalizer($assetNormalizer);
+
+        $screenshot = new Screenshot();
+        $screenshot->src = Asset::create('screenshot.png');
+        $screenshot->width = 1920;
+        $screenshot->height = 1080;
+
+        // When
+        $result = $normalizer->normalize($screenshot);
+
+        // Then
+        static::assertIsArray($result);
+        static::assertArrayNotHasKey('label', $result);
+        static::assertArrayNotHasKey('platform', $result);
+    }
+
+    #[Test]
+    public function itNormalizesScreenshotWithoutDimensionsButWithImageProcessor(): void
+    {
+        // Given
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+
+        $assetMapper->method('getAsset')
+            ->willReturn(null);
+
+        $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
+
+        $assetNormalizer = $this->createMock(NormalizerInterface::class);
+        $assetNormalizer->method('normalize')
+            ->willReturn('/assets/screenshot.png');
+        $normalizer->setNormalizer($assetNormalizer);
+
+        $screenshot = new Screenshot();
+        $screenshot->src = Asset::create('screenshot.png');
+
+        // When
+        $result = $normalizer->normalize($screenshot);
+
+        // Then
+        static::assertIsArray($result);
+        static::assertArrayNotHasKey('sizes', $result);
+    }
+}


### PR DESCRIPTION
Target branch: 1.5.x

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

## Summary

This PR adds a comprehensive screenshot generation system with PHP attributes and automatic manifest integration.

### New Features

#### 1. PHP Attribute Support (`#[Screenshot]`)

Declare screenshots directly on controller methods:

```php
use SpomkyLabs\PwaBundle\Attribute\Screenshot;

class HomeController extends AbstractController
{
    #[Route('/', name: 'app_homepage')]
    #[Screenshot(
        sizes: ['fhd', 'ipad/LP', 'iphone-14'],
        name: 'homepage',
        label: 'Application homepage',
        platform: 'windows'
    )]
    public function index(): Response
    {
        return $this->render('home/index.html.twig');
    }
}
```

#### 2. Automatic Manifest Integration

Screenshots declared with `#[Screenshot]` are **automatically added to the manifest** via `ManifestScreenshotListener`. No manual configuration needed!

#### 3. Multi-Locale Support

Generate screenshots for multiple locales with a single attribute:

```php
#[Screenshot(
    sizes: ['desktop-lg', 'tablet/LP'],
    locales: ['fr', 'en', 'de'],
    label: 'Dashboard'
)]
```

#### 4. Size Profiles with Orientation Selectors

- **Predefined profiles**: `fhd`, `iphone-14`, `ipad`, `desktop-lg`, etc.
- **Explicit dimensions**: `1920x1080`, `390x844`, etc.
- **Orientation selectors**: `/L` (landscape), `/P` (portrait), `/LP` (both)

Example: `ipad/LP` generates both 768x1024 (portrait) and 1024x768 (landscape).

#### 5. Integration with `pwa:compile`

Screenshots are automatically generated during `pwa:compile`. Use `--no-screenshots` to skip.

```sh
php bin/console pwa:compile
php bin/console pwa:compile --no-screenshots
```

### New Classes

- `SpomkyLabs\PwaBundle\Attribute\Screenshot` - PHP attribute for controller methods
- `SpomkyLabs\PwaBundle\Dto\ScreenshotConfiguration` - Configuration DTO
- `SpomkyLabs\PwaBundle\Dto\ScreenshotDimension` - Dimension handling with orientation support
- `SpomkyLabs\PwaBundle\Dto\ScreenshotSize` - Enum with all size profiles
- `SpomkyLabs\PwaBundle\Service\ScreenshotGenerator` - Screenshot generation service
- `SpomkyLabs\PwaBundle\Service\ScreenshotAttributeCollector` - Collects attributes from routes
- `SpomkyLabs\PwaBundle\Service\ScreenshotUrlGenerator` - URL generation from config
- `SpomkyLabs\PwaBundle\EventListener\ManifestScreenshotListener` - Adds screenshots to manifest

### Configuration

Configuration options under `pwa.web_client`:
- `user_agent`: Custom user agent for screenshot requests (default: `PWAScreenshotBot`)
- `web_client`: Custom Panther client service ID

The `ScreenshotListener` automatically disables the Symfony profiler/debug toolbar when the screenshot user agent is detected.