### PR TITLE
Change default page caching strategy to StaleWhileRevalidate

### DIFF
--- a/src/Resources/config/definition/service_worker.php
+++ b/src/Resources/config/definition/service_worker.php
@@ -305,9 +305,11 @@ return static function (DefinitionConfigurator $definition): void {
         ->example([1, 2, 5])
         ->end()
         ->scalarNode('strategy')
-        ->defaultValue('NetworkFirst')
-        ->info('The caching strategy. Only "NetworkFirst", "CacheFirst" and "StaleWhileRevalidate" are supported.')
-        ->example(['NetworkFirst', 'StaleWhileRevalidate', 'CacheFirst'])
+        ->defaultValue('StaleWhileRevalidate')
+        ->info(
+            'The caching strategy. Only "NetworkFirst", "CacheFirst" and "StaleWhileRevalidate" are supported. StaleWhileRevalidate provides instant page loads with background updates.'
+        )
+        ->example(['StaleWhileRevalidate', 'NetworkFirst', 'CacheFirst'])
         ->validate()
         ->ifNotInArray(CacheStrategyInterface::STRATEGIES)
         ->thenInvalid(
@@ -326,8 +328,10 @@ return static function (DefinitionConfigurator $definition): void {
         )
         ->end()
         ->booleanNode('broadcast')
-        ->defaultFalse()
-        ->info('Whether to broadcast the cache update events (for "StaleWhileRevalidate" strategy only).')
+        ->defaultTrue()
+        ->info(
+            'Whether to broadcast the cache update events (for "StaleWhileRevalidate" strategy only). Enables client notification when content is updated.'
+        )
         ->end()
         ->booleanNode('range_requests')
         ->defaultFalse()


### PR DESCRIPTION
## Summary
- Switch the default caching strategy for pages from `NetworkFirst` to `StaleWhileRevalidate`
- Enable broadcast by default to notify clients of background updates

## Benefits of StaleWhileRevalidate
- **Instant page loads** from cache
- **Background updates** fetch new content silently
- **Fresh content** on next visit
- **Better UX** for repeat visitors

## Breaking Change ⚠️
Users relying on `NetworkFirst` behavior will need to explicitly set their configuration:

```yaml
pwa:
  serviceworker:
    workbox:
      resource_caches:
        - match_callback: navigate
          strategy: NetworkFirst  # explicit override
          broadcast: false
```

## Default Configuration (after this change)
```yaml
pwa:
  serviceworker:
    workbox:
      resource_caches:
        - match_callback: navigate
          strategy: StaleWhileRevalidate  # new default
          broadcast: true  # new default
```

## Test plan
- [ ] Verify default strategy is StaleWhileRevalidate
- [ ] Verify broadcast is enabled by default
- [ ] Test explicit NetworkFirst override still works
- [ ] Document breaking change in CHANGELOG

🤖 Generated with [Claude Code](https://claude.ai/code)