### PR TITLE
Add Asset Mapper support for Resource Hints preload

### DIFF
--- a/src/Service/ResourceHintsBuilder.php
+++ b/src/Service/ResourceHintsBuilder.php
@@ -9,6 +9,7 @@ use const ENT_QUOTES;
 use SpomkyLabs\PwaBundle\Dto\PreloadResource;
 use SpomkyLabs\PwaBundle\Dto\ResourceHints;
 use function sprintf;
+use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\WebLink\Link;
@@ -23,6 +24,7 @@ final class ResourceHintsBuilder
      */
     public function __construct(
         private readonly DenormalizerInterface $denormalizer,
+        private readonly AssetMapperInterface $assetMapper,
         #[Autowire(param: 'spomky_labs_pwa.resource_hints.config')]
         private readonly array $config,
         #[Autowire(param: 'spomky_labs_pwa.sw.config')]
@@ -131,7 +133,8 @@ final class ResourceHintsBuilder
 
     private function createPreloadLink(PreloadResource $resource): Link
     {
-        $link = (new Link(Link::REL_PRELOAD, $resource->href))
+        $href = $this->resolveHref($resource->href);
+        $link = (new Link(Link::REL_PRELOAD, $href))
             ->withAttribute('as', $resource->as);
 
         if ($resource->type !== null) {
@@ -154,6 +157,24 @@ final class ResourceHintsBuilder
         }
 
         return $link;
+    }
+
+    /**
+     * Resolve href to a public URL.
+     * If href starts with / or is an absolute URL, return as-is.
+     * Otherwise, treat as an Asset Mapper logical path and resolve it.
+     */
+    private function resolveHref(string $href): string
+    {
+        // Absolute URL or path starting with /
+        if (str_starts_with($href, '/') || str_starts_with($href, 'http://') || str_starts_with($href, 'https://')) {
+            return $href;
+        }
+
+        // Try to resolve as Asset Mapper logical path
+        $publicPath = $this->assetMapper->getPublicPath($href);
+
+        return $publicPath ?? '/' . $href;
     }
 
     private function renderLinkAsHtml(Link $link): string

--- a/tests/Unit/Service/ResourceHintsBuilderTest.php
+++ b/tests/Unit/Service/ResourceHintsBuilderTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use SpomkyLabs\PwaBundle\Dto\PreloadResource;
 use SpomkyLabs\PwaBundle\Dto\ResourceHints;
 use SpomkyLabs\PwaBundle\Service\ResourceHintsBuilder;
+use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\WebLink\Link;
 
@@ -317,7 +318,121 @@ final class ResourceHintsBuilderTest extends TestCase
         $html = $builder->generateHtml();
 
         // Then
-        static::assertSame('', $html);
+        self::assertSame('', $html);
+    }
+
+    #[Test]
+    public function itResolvesAssetMapperPaths(): void
+    {
+        // Given
+        $fontPreload = new PreloadResource();
+        $fontPreload->href = 'fonts/inter-var.woff2'; // Asset Mapper logical path (no leading /)
+        $fontPreload->as = 'font';
+
+        $hints = new ResourceHints();
+        $hints->enabled = true;
+        $hints->autoPreconnect = false;
+        $hints->preload = [$fontPreload];
+
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $assetMapper
+            ->method('getPublicPath')
+            ->with('fonts/inter-var.woff2')
+            ->willReturn('/assets/fonts/inter-var-abc123.woff2');
+
+        $builder = $this->createBuilder($hints, ['enabled' => true], [], $assetMapper);
+
+        // When
+        $links = $builder->getLinks();
+
+        // Then
+        self::assertCount(1, $links);
+        self::assertSame('/assets/fonts/inter-var-abc123.woff2', $links[0]->getHref());
+    }
+
+    #[Test]
+    public function itKeepsAbsolutePathsUnchanged(): void
+    {
+        // Given
+        $fontPreload = new PreloadResource();
+        $fontPreload->href = '/fonts/custom.woff2'; // Absolute path (starts with /)
+        $fontPreload->as = 'font';
+
+        $hints = new ResourceHints();
+        $hints->enabled = true;
+        $hints->autoPreconnect = false;
+        $hints->preload = [$fontPreload];
+
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $assetMapper
+            ->expects(self::never())
+            ->method('getPublicPath');
+
+        $builder = $this->createBuilder($hints, ['enabled' => true], [], $assetMapper);
+
+        // When
+        $links = $builder->getLinks();
+
+        // Then
+        self::assertCount(1, $links);
+        self::assertSame('/fonts/custom.woff2', $links[0]->getHref());
+    }
+
+    #[Test]
+    public function itKeepsAbsoluteUrlsUnchanged(): void
+    {
+        // Given
+        $fontPreload = new PreloadResource();
+        $fontPreload->href = 'https://cdn.example.com/fonts/custom.woff2';
+        $fontPreload->as = 'font';
+
+        $hints = new ResourceHints();
+        $hints->enabled = true;
+        $hints->autoPreconnect = false;
+        $hints->preload = [$fontPreload];
+
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $assetMapper
+            ->expects(self::never())
+            ->method('getPublicPath');
+
+        $builder = $this->createBuilder($hints, ['enabled' => true], [], $assetMapper);
+
+        // When
+        $links = $builder->getLinks();
+
+        // Then
+        self::assertCount(1, $links);
+        self::assertSame('https://cdn.example.com/fonts/custom.woff2', $links[0]->getHref());
+    }
+
+    #[Test]
+    public function itFallsBackToSlashPrefixWhenAssetNotFound(): void
+    {
+        // Given
+        $fontPreload = new PreloadResource();
+        $fontPreload->href = 'fonts/unknown.woff2';
+        $fontPreload->as = 'font';
+
+        $hints = new ResourceHints();
+        $hints->enabled = true;
+        $hints->autoPreconnect = false;
+        $hints->preload = [$fontPreload];
+
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $assetMapper
+            ->method('getPublicPath')
+            ->with('fonts/unknown.woff2')
+            ->willReturn(null);
+
+        $builder = $this->createBuilder($hints, ['enabled' => true], [], $assetMapper);
+
+        // When
+        $links = $builder->getLinks();
+
+        // Then
+        self::assertCount(1, $links);
+        self::assertSame('/fonts/unknown.woff2', $links[0]->getHref());
     }
 
     /**
@@ -327,13 +442,16 @@ final class ResourceHintsBuilderTest extends TestCase
     private function createBuilder(
         ResourceHints $hints,
         array $config,
-        array $workboxConfig = []
+        array $workboxConfig = [],
+        ?AssetMapperInterface $assetMapper = null
     ): ResourceHintsBuilder {
         $denormalizer = $this->createMock(DenormalizerInterface::class);
         $denormalizer
             ->method('denormalize')
             ->willReturn($hints);
 
-        return new ResourceHintsBuilder($denormalizer, $config, $workboxConfig);
+        $assetMapper ??= $this->createMock(AssetMapperInterface::class);
+
+        return new ResourceHintsBuilder($denormalizer, $assetMapper, $config, $workboxConfig);
     }
 }

--- a/tests/Unit/Service/ResourceHintsBuilderTest.php
+++ b/tests/Unit/Service/ResourceHintsBuilderTest.php
@@ -318,7 +318,7 @@ final class ResourceHintsBuilderTest extends TestCase
         $html = $builder->generateHtml();
 
         // Then
-        self::assertSame('', $html);
+        static::assertSame('', $html);
     }
 
     #[Test]
@@ -340,14 +340,16 @@ final class ResourceHintsBuilderTest extends TestCase
             ->with('fonts/inter-var.woff2')
             ->willReturn('/assets/fonts/inter-var-abc123.woff2');
 
-        $builder = $this->createBuilder($hints, ['enabled' => true], [], $assetMapper);
+        $builder = $this->createBuilder($hints, [
+            'enabled' => true,
+        ], [], $assetMapper);
 
         // When
         $links = $builder->getLinks();
 
         // Then
-        self::assertCount(1, $links);
-        self::assertSame('/assets/fonts/inter-var-abc123.woff2', $links[0]->getHref());
+        static::assertCount(1, $links);
+        static::assertSame('/assets/fonts/inter-var-abc123.woff2', $links[0]->getHref());
     }
 
     #[Test]
@@ -365,17 +367,19 @@ final class ResourceHintsBuilderTest extends TestCase
 
         $assetMapper = $this->createMock(AssetMapperInterface::class);
         $assetMapper
-            ->expects(self::never())
+            ->expects(static::never())
             ->method('getPublicPath');
 
-        $builder = $this->createBuilder($hints, ['enabled' => true], [], $assetMapper);
+        $builder = $this->createBuilder($hints, [
+            'enabled' => true,
+        ], [], $assetMapper);
 
         // When
         $links = $builder->getLinks();
 
         // Then
-        self::assertCount(1, $links);
-        self::assertSame('/fonts/custom.woff2', $links[0]->getHref());
+        static::assertCount(1, $links);
+        static::assertSame('/fonts/custom.woff2', $links[0]->getHref());
     }
 
     #[Test]
@@ -393,17 +397,19 @@ final class ResourceHintsBuilderTest extends TestCase
 
         $assetMapper = $this->createMock(AssetMapperInterface::class);
         $assetMapper
-            ->expects(self::never())
+            ->expects(static::never())
             ->method('getPublicPath');
 
-        $builder = $this->createBuilder($hints, ['enabled' => true], [], $assetMapper);
+        $builder = $this->createBuilder($hints, [
+            'enabled' => true,
+        ], [], $assetMapper);
 
         // When
         $links = $builder->getLinks();
 
         // Then
-        self::assertCount(1, $links);
-        self::assertSame('https://cdn.example.com/fonts/custom.woff2', $links[0]->getHref());
+        static::assertCount(1, $links);
+        static::assertSame('https://cdn.example.com/fonts/custom.woff2', $links[0]->getHref());
     }
 
     #[Test]
@@ -425,14 +431,16 @@ final class ResourceHintsBuilderTest extends TestCase
             ->with('fonts/unknown.woff2')
             ->willReturn(null);
 
-        $builder = $this->createBuilder($hints, ['enabled' => true], [], $assetMapper);
+        $builder = $this->createBuilder($hints, [
+            'enabled' => true,
+        ], [], $assetMapper);
 
         // When
         $links = $builder->getLinks();
 
         // Then
-        self::assertCount(1, $links);
-        self::assertSame('/fonts/unknown.woff2', $links[0]->getHref());
+        static::assertCount(1, $links);
+        static::assertSame('/fonts/unknown.woff2', $links[0]->getHref());
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add Asset Mapper path resolution for preload resources in Resource Hints
- Paths without leading `/` or `http(s)://` are treated as Asset Mapper logical paths
- Resolved to versioned URLs automatically

## Dependencies
This PR builds on top of PR #413 (Resource Hints feature).

## Usage

```yaml
pwa:
  resource_hints:
    preload:
      # Asset Mapper path (no leading /) - resolved to versioned URL
      - href: 'fonts/inter-var.woff2'
        as: font
        type: 'font/woff2'
      # Absolute path - kept as-is
      - href: '/fonts/custom.woff2'
        as: font
      # External URL - kept as-is
      - href: 'https://cdn.example.com/font.woff2'
        as: font
```

## Resolution Rules

| Input | Output |
|-------|--------|
| `fonts/inter.woff2` | `/assets/fonts/inter-abc123.woff2` (versioned) |
| `/fonts/custom.woff2` | `/fonts/custom.woff2` (unchanged) |
| `https://cdn.example.com/font.woff2` | `https://cdn.example.com/font.woff2` (unchanged) |

If the Asset Mapper can't find the asset, falls back to `/{path}`.

## Test plan
- [x] Asset Mapper paths are resolved to versioned URLs
- [x] Absolute paths (starting with /) are unchanged
- [x] Absolute URLs (http/https) are unchanged
- [x] Fallback to /{path} when asset not found

🤖 Generated with [Claude Code](https://claude.ai/code)