### PR TITLE
Add ResourceHintsListener for Early Hints support

### DIFF
--- a/src/EventListener/ResourceHintsListener.php
+++ b/src/EventListener/ResourceHintsListener.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\EventListener;
+
+use SpomkyLabs\PwaBundle\Service\ResourceHintsBuilder;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\WebLink\GenericLinkProvider;
+
+/**
+ * Adds Resource Hints Link headers early in the request cycle.
+ *
+ * This allows compatible servers (FrankenPHP, Caddy) to send HTTP 103 Early Hints
+ * responses with preconnect, dns-prefetch, and preload hints before the main
+ * response is ready.
+ *
+ * @see https://developer.chrome.com/docs/web-platform/early-hints
+ */
+#[AsEventListener(event: 'kernel.request', priority: 99)]
+final readonly class ResourceHintsListener
+{
+    public function __construct(
+        private ResourceHintsBuilder $resourceHintsBuilder,
+    ) {
+    }
+
+    public function __invoke(RequestEvent $event): void
+    {
+        if (! $this->resourceHintsBuilder->isEnabled()) {
+            return;
+        }
+
+        if (! $event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        // Only add hints for HTML requests
+        $acceptHeader = $request->headers->get('Accept', '');
+        if (! str_contains((string) $acceptHeader, 'text/html')) {
+            return;
+        }
+
+        $links = $this->resourceHintsBuilder->getLinks();
+        if ($links === []) {
+            return;
+        }
+
+        // Get existing link provider or create a new one
+        $linkProvider = $request->attributes->get('_links');
+        if (! $linkProvider instanceof GenericLinkProvider) {
+            $linkProvider = new GenericLinkProvider();
+        }
+
+        // Add resource hint links
+        foreach ($links as $link) {
+            $linkProvider = $linkProvider->withLink($link);
+        }
+
+        $request->attributes->set('_links', $linkProvider);
+    }
+}

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -16,6 +16,7 @@ use SpomkyLabs\PwaBundle\DataCollector\PwaCollector;
 use SpomkyLabs\PwaBundle\EventListener\EarlyHintsListener;
 use SpomkyLabs\PwaBundle\EventListener\FileCompileEventListener;
 use SpomkyLabs\PwaBundle\EventListener\PwaDevServerListener;
+use SpomkyLabs\PwaBundle\EventListener\ResourceHintsListener;
 use SpomkyLabs\PwaBundle\EventListener\ScreenshotListener;
 use SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor;
 use SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor;
@@ -128,6 +129,7 @@ return static function (ContainerConfigurator $configurator): void {
             '$manifestPublicUrl' => param('spomky_labs_pwa.manifest.public_url'),
         ])
     ;
+    $container->set(ResourceHintsListener::class);
     $container->set(PwaDevServerListener::class)
         ->args([
             '$profiler' => service('profiler')

--- a/tests/Unit/EventListener/ResourceHintsListenerTest.php
+++ b/tests/Unit/EventListener/ResourceHintsListenerTest.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\PwaBundle\Tests\Unit\EventListener;
 
+use function in_array;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use SpomkyLabs\PwaBundle\Dto\PreloadResource;
 use SpomkyLabs\PwaBundle\Dto\ResourceHints;
 use SpomkyLabs\PwaBundle\EventListener\ResourceHintsListener;
 use SpomkyLabs\PwaBundle\Service\ResourceHintsBuilder;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -32,7 +35,9 @@ final class ResourceHintsListenerTest extends TestCase
         $hints->autoPreconnect = false;
         $hints->preconnect = ['https://api.example.com'];
 
-        $listener = $this->createListener($hints, ['enabled' => true]);
+        $listener = $this->createListener($hints, [
+            'enabled' => true,
+        ]);
 
         $request = new Request();
         $request->headers->set('Accept', 'text/html');
@@ -43,13 +48,13 @@ final class ResourceHintsListenerTest extends TestCase
 
         // Then
         $linkProvider = $request->attributes->get('_links');
-        self::assertInstanceOf(GenericLinkProvider::class, $linkProvider);
+        static::assertInstanceOf(GenericLinkProvider::class, $linkProvider);
 
         $links = $linkProvider->getLinks();
-        self::assertNotEmpty($links);
+        static::assertNotEmpty($links);
 
         $hrefs = array_map(fn ($link) => $link->getHref(), $links);
-        self::assertContains('https://api.example.com', $hrefs);
+        static::assertContains('https://api.example.com', $hrefs);
     }
 
     #[Test]
@@ -59,7 +64,9 @@ final class ResourceHintsListenerTest extends TestCase
         $hints = new ResourceHints();
         $hints->enabled = false;
 
-        $listener = $this->createListener($hints, ['enabled' => false]);
+        $listener = $this->createListener($hints, [
+            'enabled' => false,
+        ]);
 
         $request = new Request();
         $request->headers->set('Accept', 'text/html');
@@ -69,7 +76,7 @@ final class ResourceHintsListenerTest extends TestCase
         $listener($event);
 
         // Then
-        self::assertNull($request->attributes->get('_links'));
+        static::assertNull($request->attributes->get('_links'));
     }
 
     #[Test]
@@ -81,7 +88,9 @@ final class ResourceHintsListenerTest extends TestCase
         $hints->autoPreconnect = false;
         $hints->preconnect = ['https://api.example.com'];
 
-        $listener = $this->createListener($hints, ['enabled' => true]);
+        $listener = $this->createListener($hints, [
+            'enabled' => true,
+        ]);
 
         $request = new Request();
         $request->headers->set('Accept', 'application/json');
@@ -91,7 +100,7 @@ final class ResourceHintsListenerTest extends TestCase
         $listener($event);
 
         // Then
-        self::assertNull($request->attributes->get('_links'));
+        static::assertNull($request->attributes->get('_links'));
     }
 
     #[Test]
@@ -103,7 +112,9 @@ final class ResourceHintsListenerTest extends TestCase
         $hints->autoPreconnect = false;
         $hints->preconnect = ['https://api.example.com'];
 
-        $listener = $this->createListener($hints, ['enabled' => true]);
+        $listener = $this->createListener($hints, [
+            'enabled' => true,
+        ]);
 
         $request = new Request();
         $request->headers->set('Accept', 'text/html');
@@ -113,7 +124,7 @@ final class ResourceHintsListenerTest extends TestCase
         $listener($event);
 
         // Then
-        self::assertNull($request->attributes->get('_links'));
+        static::assertNull($request->attributes->get('_links'));
     }
 
     #[Test]
@@ -125,7 +136,9 @@ final class ResourceHintsListenerTest extends TestCase
         $hints->autoPreconnect = false;
         $hints->preconnect = ['https://api.example.com', 'https://cdn.example.com'];
 
-        $listener = $this->createListener($hints, ['enabled' => true]);
+        $listener = $this->createListener($hints, [
+            'enabled' => true,
+        ]);
 
         $request = new Request();
         $request->headers->set('Accept', 'text/html');
@@ -139,7 +152,7 @@ final class ResourceHintsListenerTest extends TestCase
         $links = $linkProvider->getLinks();
 
         $preconnectLinks = array_filter($links, fn ($link) => in_array(Link::REL_PRECONNECT, $link->getRels(), true));
-        self::assertCount(2, $preconnectLinks);
+        static::assertCount(2, $preconnectLinks);
     }
 
     #[Test]
@@ -151,7 +164,9 @@ final class ResourceHintsListenerTest extends TestCase
         $hints->autoPreconnect = false;
         $hints->dnsPrefetch = ['https://analytics.example.com'];
 
-        $listener = $this->createListener($hints, ['enabled' => true]);
+        $listener = $this->createListener($hints, [
+            'enabled' => true,
+        ]);
 
         $request = new Request();
         $request->headers->set('Accept', 'text/html');
@@ -168,7 +183,7 @@ final class ResourceHintsListenerTest extends TestCase
             $links,
             fn ($link) => in_array(Link::REL_DNS_PREFETCH, $link->getRels(), true)
         );
-        self::assertCount(1, $dnsPrefetchLinks);
+        static::assertCount(1, $dnsPrefetchLinks);
     }
 
     #[Test]
@@ -185,7 +200,9 @@ final class ResourceHintsListenerTest extends TestCase
         $hints->autoPreconnect = false;
         $hints->preload = [$fontPreload];
 
-        $listener = $this->createListener($hints, ['enabled' => true]);
+        $listener = $this->createListener($hints, [
+            'enabled' => true,
+        ]);
 
         $request = new Request();
         $request->headers->set('Accept', 'text/html');
@@ -199,11 +216,11 @@ final class ResourceHintsListenerTest extends TestCase
         $links = $linkProvider->getLinks();
 
         $preloadLinks = array_filter($links, fn ($link) => in_array(Link::REL_PRELOAD, $link->getRels(), true));
-        self::assertCount(1, $preloadLinks);
+        static::assertCount(1, $preloadLinks);
 
         $preloadLink = reset($preloadLinks);
-        self::assertSame('/fonts/custom.woff2', $preloadLink->getHref());
-        self::assertSame('font', $preloadLink->getAttributes()['as']);
+        static::assertSame('/fonts/custom.woff2', $preloadLink->getHref());
+        static::assertSame('font', $preloadLink->getAttributes()['as']);
     }
 
     #[Test]
@@ -215,7 +232,9 @@ final class ResourceHintsListenerTest extends TestCase
         $hints->autoPreconnect = false;
         $hints->preconnect = ['https://api.example.com'];
 
-        $listener = $this->createListener($hints, ['enabled' => true]);
+        $listener = $this->createListener($hints, [
+            'enabled' => true,
+        ]);
 
         $existingLink = new Link('preload', '/existing-resource.js');
         $existingProvider = (new GenericLinkProvider())->withLink($existingLink);
@@ -233,8 +252,8 @@ final class ResourceHintsListenerTest extends TestCase
         $links = $linkProvider->getLinks();
 
         $hrefs = array_map(fn ($link) => $link->getHref(), $links);
-        self::assertContains('/existing-resource.js', $hrefs);
-        self::assertContains('https://api.example.com', $hrefs);
+        static::assertContains('/existing-resource.js', $hrefs);
+        static::assertContains('https://api.example.com', $hrefs);
     }
 
     #[Test]
@@ -242,20 +261,20 @@ final class ResourceHintsListenerTest extends TestCase
     {
         // ResourceHintsListener should run after EarlyHintsListener (priority 100)
         // so it has priority 99
-        $reflection = new \ReflectionClass(ResourceHintsListener::class);
+        $reflection = new ReflectionClass(ResourceHintsListener::class);
         $attributes = $reflection->getAttributes();
 
         $listenerAttribute = null;
         foreach ($attributes as $attribute) {
-            if ($attribute->getName() === 'Symfony\Component\EventDispatcher\Attribute\AsEventListener') {
+            if ($attribute->getName() === AsEventListener::class) {
                 $listenerAttribute = $attribute;
                 break;
             }
         }
 
-        self::assertNotNull($listenerAttribute);
+        static::assertNotNull($listenerAttribute);
         $args = $listenerAttribute->getArguments();
-        self::assertSame(99, $args['priority']);
+        static::assertSame(99, $args['priority']);
     }
 
     /**
@@ -271,7 +290,7 @@ final class ResourceHintsListenerTest extends TestCase
         $assetMapper = $this->createMock(AssetMapperInterface::class);
         $assetMapper
             ->method('getPublicPath')
-            ->willReturnCallback(fn ($path) => '/' . $path);
+            ->willReturnCallback(fn (string $path): string => '/' . $path);
 
         $resourceHintsBuilder = new ResourceHintsBuilder($denormalizer, $assetMapper, $config, []);
 

--- a/tests/Unit/EventListener/ResourceHintsListenerTest.php
+++ b/tests/Unit/EventListener/ResourceHintsListenerTest.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Unit\EventListener;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\PwaBundle\Dto\PreloadResource;
+use SpomkyLabs\PwaBundle\Dto\ResourceHints;
+use SpomkyLabs\PwaBundle\EventListener\ResourceHintsListener;
+use SpomkyLabs\PwaBundle\Service\ResourceHintsBuilder;
+use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\WebLink\GenericLinkProvider;
+use Symfony\Component\WebLink\Link;
+
+/**
+ * @internal
+ */
+final class ResourceHintsListenerTest extends TestCase
+{
+    #[Test]
+    public function itAddsLinkHeadersToHtmlRequests(): void
+    {
+        // Given
+        $hints = new ResourceHints();
+        $hints->enabled = true;
+        $hints->autoPreconnect = false;
+        $hints->preconnect = ['https://api.example.com'];
+
+        $listener = $this->createListener($hints, ['enabled' => true]);
+
+        $request = new Request();
+        $request->headers->set('Accept', 'text/html');
+        $event = $this->createRequestEvent($request);
+
+        // When
+        $listener($event);
+
+        // Then
+        $linkProvider = $request->attributes->get('_links');
+        self::assertInstanceOf(GenericLinkProvider::class, $linkProvider);
+
+        $links = $linkProvider->getLinks();
+        self::assertNotEmpty($links);
+
+        $hrefs = array_map(fn ($link) => $link->getHref(), $links);
+        self::assertContains('https://api.example.com', $hrefs);
+    }
+
+    #[Test]
+    public function itDoesNothingWhenDisabled(): void
+    {
+        // Given
+        $hints = new ResourceHints();
+        $hints->enabled = false;
+
+        $listener = $this->createListener($hints, ['enabled' => false]);
+
+        $request = new Request();
+        $request->headers->set('Accept', 'text/html');
+        $event = $this->createRequestEvent($request);
+
+        // When
+        $listener($event);
+
+        // Then
+        self::assertNull($request->attributes->get('_links'));
+    }
+
+    #[Test]
+    public function itDoesNothingForNonHtmlRequests(): void
+    {
+        // Given
+        $hints = new ResourceHints();
+        $hints->enabled = true;
+        $hints->autoPreconnect = false;
+        $hints->preconnect = ['https://api.example.com'];
+
+        $listener = $this->createListener($hints, ['enabled' => true]);
+
+        $request = new Request();
+        $request->headers->set('Accept', 'application/json');
+        $event = $this->createRequestEvent($request);
+
+        // When
+        $listener($event);
+
+        // Then
+        self::assertNull($request->attributes->get('_links'));
+    }
+
+    #[Test]
+    public function itDoesNothingForSubRequests(): void
+    {
+        // Given
+        $hints = new ResourceHints();
+        $hints->enabled = true;
+        $hints->autoPreconnect = false;
+        $hints->preconnect = ['https://api.example.com'];
+
+        $listener = $this->createListener($hints, ['enabled' => true]);
+
+        $request = new Request();
+        $request->headers->set('Accept', 'text/html');
+        $event = $this->createRequestEvent($request, HttpKernelInterface::SUB_REQUEST);
+
+        // When
+        $listener($event);
+
+        // Then
+        self::assertNull($request->attributes->get('_links'));
+    }
+
+    #[Test]
+    public function itAddsPreconnectLinks(): void
+    {
+        // Given
+        $hints = new ResourceHints();
+        $hints->enabled = true;
+        $hints->autoPreconnect = false;
+        $hints->preconnect = ['https://api.example.com', 'https://cdn.example.com'];
+
+        $listener = $this->createListener($hints, ['enabled' => true]);
+
+        $request = new Request();
+        $request->headers->set('Accept', 'text/html');
+        $event = $this->createRequestEvent($request);
+
+        // When
+        $listener($event);
+
+        // Then
+        $linkProvider = $request->attributes->get('_links');
+        $links = $linkProvider->getLinks();
+
+        $preconnectLinks = array_filter($links, fn ($link) => in_array(Link::REL_PRECONNECT, $link->getRels(), true));
+        self::assertCount(2, $preconnectLinks);
+    }
+
+    #[Test]
+    public function itAddsDnsPrefetchLinks(): void
+    {
+        // Given
+        $hints = new ResourceHints();
+        $hints->enabled = true;
+        $hints->autoPreconnect = false;
+        $hints->dnsPrefetch = ['https://analytics.example.com'];
+
+        $listener = $this->createListener($hints, ['enabled' => true]);
+
+        $request = new Request();
+        $request->headers->set('Accept', 'text/html');
+        $event = $this->createRequestEvent($request);
+
+        // When
+        $listener($event);
+
+        // Then
+        $linkProvider = $request->attributes->get('_links');
+        $links = $linkProvider->getLinks();
+
+        $dnsPrefetchLinks = array_filter(
+            $links,
+            fn ($link) => in_array(Link::REL_DNS_PREFETCH, $link->getRels(), true)
+        );
+        self::assertCount(1, $dnsPrefetchLinks);
+    }
+
+    #[Test]
+    public function itAddsPreloadLinks(): void
+    {
+        // Given
+        $fontPreload = new PreloadResource();
+        $fontPreload->href = '/fonts/custom.woff2';
+        $fontPreload->as = 'font';
+        $fontPreload->type = 'font/woff2';
+
+        $hints = new ResourceHints();
+        $hints->enabled = true;
+        $hints->autoPreconnect = false;
+        $hints->preload = [$fontPreload];
+
+        $listener = $this->createListener($hints, ['enabled' => true]);
+
+        $request = new Request();
+        $request->headers->set('Accept', 'text/html');
+        $event = $this->createRequestEvent($request);
+
+        // When
+        $listener($event);
+
+        // Then
+        $linkProvider = $request->attributes->get('_links');
+        $links = $linkProvider->getLinks();
+
+        $preloadLinks = array_filter($links, fn ($link) => in_array(Link::REL_PRELOAD, $link->getRels(), true));
+        self::assertCount(1, $preloadLinks);
+
+        $preloadLink = reset($preloadLinks);
+        self::assertSame('/fonts/custom.woff2', $preloadLink->getHref());
+        self::assertSame('font', $preloadLink->getAttributes()['as']);
+    }
+
+    #[Test]
+    public function itPreservesExistingLinkProvider(): void
+    {
+        // Given
+        $hints = new ResourceHints();
+        $hints->enabled = true;
+        $hints->autoPreconnect = false;
+        $hints->preconnect = ['https://api.example.com'];
+
+        $listener = $this->createListener($hints, ['enabled' => true]);
+
+        $existingLink = new Link('preload', '/existing-resource.js');
+        $existingProvider = (new GenericLinkProvider())->withLink($existingLink);
+
+        $request = new Request();
+        $request->headers->set('Accept', 'text/html');
+        $request->attributes->set('_links', $existingProvider);
+        $event = $this->createRequestEvent($request);
+
+        // When
+        $listener($event);
+
+        // Then
+        $linkProvider = $request->attributes->get('_links');
+        $links = $linkProvider->getLinks();
+
+        $hrefs = array_map(fn ($link) => $link->getHref(), $links);
+        self::assertContains('/existing-resource.js', $hrefs);
+        self::assertContains('https://api.example.com', $hrefs);
+    }
+
+    #[Test]
+    public function itHasLowerPriorityThanEarlyHintsListener(): void
+    {
+        // ResourceHintsListener should run after EarlyHintsListener (priority 100)
+        // so it has priority 99
+        $reflection = new \ReflectionClass(ResourceHintsListener::class);
+        $attributes = $reflection->getAttributes();
+
+        $listenerAttribute = null;
+        foreach ($attributes as $attribute) {
+            if ($attribute->getName() === 'Symfony\Component\EventDispatcher\Attribute\AsEventListener') {
+                $listenerAttribute = $attribute;
+                break;
+            }
+        }
+
+        self::assertNotNull($listenerAttribute);
+        $args = $listenerAttribute->getArguments();
+        self::assertSame(99, $args['priority']);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function createListener(ResourceHints $hints, array $config): ResourceHintsListener
+    {
+        $denormalizer = $this->createMock(DenormalizerInterface::class);
+        $denormalizer
+            ->method('denormalize')
+            ->willReturn($hints);
+
+        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $assetMapper
+            ->method('getPublicPath')
+            ->willReturnCallback(fn ($path) => '/' . $path);
+
+        $resourceHintsBuilder = new ResourceHintsBuilder($denormalizer, $assetMapper, $config, []);
+
+        return new ResourceHintsListener($resourceHintsBuilder);
+    }
+
+    private function createRequestEvent(
+        Request $request,
+        int $requestType = HttpKernelInterface::MAIN_REQUEST
+    ): RequestEvent {
+        $kernel = $this->createMock(HttpKernelInterface::class);
+
+        return new RequestEvent($kernel, $request, $requestType);
+    }
+}


### PR DESCRIPTION
## Summary
Add a listener that injects Resource Hints Link headers early in the request cycle, enabling HTTP 103 Early Hints support for custom resources (fonts, CSS, images, etc.).

## How it works
The `ResourceHintsListener` runs on `kernel.request` with priority 99 (after `EarlyHintsListener` at 100). It uses the existing `ResourceHintsBuilder` to add Link headers to the request early in the cycle.

When using a compatible server (FrankenPHP, Caddy), these headers are sent as 103 Early Hints before the main response, allowing browsers to start loading critical resources immediately.

## Benefits
- **Fonts load faster**: Preload hints sent via 103 before HTML arrives
- **CSS loads earlier**: Critical CSS can start loading during server processing
- **Preconnect benefits from Early Hints**: External connections established sooner
- **Zero configuration**: Works automatically with existing `resource_hints` config

## Example
```yaml
pwa:
  resource_hints:
    enabled: true
    preconnect:
      - 'https://api.example.com'
    preload:
      - href: 'fonts/inter.woff2'
        as: font
```

With a compatible server, these hints are sent as:
```http
HTTP/1.1 103 Early Hints
Link: <https://api.example.com>; rel="preconnect"; crossorigin
Link: </assets/fonts/inter-abc123.woff2>; rel="preload"; as="font"; crossorigin="anonymous"

HTTP/1.1 200 OK
...
```

## Test plan
- [x] Link headers added to HTML requests
- [x] Disabled when resource_hints.enabled is false
- [x] Non-HTML requests ignored
- [x] Sub-requests ignored
- [x] Preconnect links added
- [x] DNS-prefetch links added
- [x] Preload links added
- [x] Existing LinkProvider preserved
- [x] Priority is lower than EarlyHintsListener

🤖 Generated with [Claude Code](https://claude.ai/code)