### PR TITLE
Fix CSP compatibility for service worker registration script

### DIFF
--- a/src/Twig/PwaRuntime.php
+++ b/src/Twig/PwaRuntime.php
@@ -152,9 +152,14 @@ final readonly class PwaRuntime
             );
             // Using UMD version instead of ESM to avoid importmap dependency issues
             // This prevents "bare specifier not remapped" errors regardless of script order.
-            // See: https://github.com/Spomky-Labs/pwa-bundle/issues/391
+            // See: https://github.com/Spomky-Labs/pwa-bundle/pull/393
+            // Using separate scripts instead of onload attribute for CSP compatibility.
+            // Inline event handlers are blocked by CSP even with nonces.
+            // Both scripts use defer, so they execute in document order after DOM is ready.
             $declaration = <<<SERVICE_WORKER
-<script src="{$workboxUrl}" defer{$scriptAttributes} onload="(async () => {
+<script src="{$workboxUrl}" defer></script>
+<script defer{$scriptAttributes}>
+(async () => {
   if ('serviceWorker' in navigator) {
     try {
       const wb = new workbox.Workbox('{$url}'{$registerOptions});
@@ -178,7 +183,8 @@ final readonly class PwaRuntime
       console.error('SW registration failed', e);
     }
   }
-})()"></script>
+})();
+</script>
 SERVICE_WORKER;
         } else {
             $declaration = <<<SERVICE_WORKER

--- a/tests/Unit/EventListener/ScreenshotListenerTest.php
+++ b/tests/Unit/EventListener/ScreenshotListenerTest.php
@@ -172,8 +172,7 @@ final class ScreenshotListenerTest extends TestCase
     public function itLogsDebugMessages(): void
     {
         // Given
-        $profiler = $this->createMock(Profiler::class);
-        $listener = new ScreenshotListener($profiler, 'HeadlessChrome');
+        $listener = new ScreenshotListener(static::createStub(Profiler::class), 'HeadlessChrome');
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(static::atLeastOnce())


### PR DESCRIPTION
## Summary
- Replace `onload` attribute with separate `<script defer>` tag for CSP compatibility
- Inline event handlers (`onload`, `onclick`, etc.) are blocked by CSP even with valid nonces
- Both scripts use `defer`, ensuring execution order is preserved

## Problem
When CSP is enabled with a nonce, the service worker registration fails with:
```
Executing inline event handler violates the following Content Security Policy directive 'script-src 'self' 'nonce-...''. Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution.
```

This happens because CSP nonces only apply to `<script>` content, not to inline event handlers like `onload`.

## Solution
Split the single script with `onload` into two separate scripts:
1. `<script src="workbox-window.prod.umd.js" defer></script>` - loads Workbox
2. `<script defer nonce="...">...</script>` - registration code with nonce

Since both use `defer`, they execute in document order after DOM is ready.

## Test plan
- [ ] Test with CSP enabled (nonce-based policy)
- [ ] Test in Chrome
- [ ] Test in Firefox
- [ ] Verify service worker registers correctly

🤖 Generated with [Claude Code](https://claude.ai/code)