### PR TITLE
Fix SKIP_WAITING handler missing clients.claim()

### DIFF
--- a/src/ServiceWorkerRule/WorkboxHelpers.php
+++ b/src/ServiceWorkerRule/WorkboxHelpers.php
@@ -170,6 +170,7 @@ function statusGuard(min, max) {
 registerMessageTask(async (event) => {
   if (event.data?.type === 'SKIP_WAITING') {
     await self.skipWaiting();
+    await self.clients.claim();
   }
 });
 


### PR DESCRIPTION
## Summary

- The `SKIP_WAITING` message handler in `WorkboxHelpers.php` calls `self.skipWaiting()` but not `self.clients.claim()`, so the newly activated service worker does not take control of existing clients
- The `controllerchange` event never fires, meaning the page does not reload after the user triggers a manual update (e.g., clicking an "Update available" button)
- Added `await self.clients.claim()` right after `await self.skipWaiting()` to ensure the SW claims all clients upon activation

## Test plan

- [x] Full test suite passes (106 tests, 266 assertions)
- [ ] Verify that clicking "Update available" correctly reloads the page with the new SW
- [ ] Verify that DevTools > Application > Service Workers > skipWaiting also triggers a proper reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)