### PR TITLE
Fix unknown "instanceof" Twig test

### DIFF
--- a/src/SpomkyLabsPwaBundle.php
+++ b/src/SpomkyLabsPwaBundle.php
@@ -120,10 +120,14 @@ final class SpomkyLabsPwaBundle extends AbstractBundle
 
     private function setAssetMapperPath(ContainerBuilder $builder): void
     {
+        $path = realpath(__DIR__ . '/../assets/src');
+        if ($path === false) {
+            return;
+        }
         $builder->prependExtensionConfig('framework', [
             'asset_mapper' => [
                 'paths' => [
-                    realpath(__DIR__ . '/../assets/src') => '@spomky-labs/pwa-bundle',
+                    $path => '@spomky-labs/pwa-bundle',
                 ],
             ],
         ]);

--- a/src/Twig/InstanceOfExtension.php
+++ b/src/Twig/InstanceOfExtension.php
@@ -7,23 +7,16 @@ namespace SpomkyLabs\PwaBundle\Twig;
 use ReflectionClass;
 use Twig\Attribute\AsTwigFilter;
 use Twig\Attribute\AsTwigFunction;
-use Twig\TwigTest;
+use Twig\Attribute\AsTwigTest;
 
 class InstanceOfExtension
 {
-    /**
-     * @return array<TwigTest>
-     */
-    public function getTests(): array
-    {
-        return [new TwigTest('instanceof', $this->isInstanceOf(...))];
-    }
-
     /**
      * @param class-string $instance
      */
     #[AsTwigFilter('instanceof')]
     #[AsTwigFunction('instanceof')]
+    #[AsTwigTest('instanceof')]
     public function isInstanceOf(object $var, string $instance): bool
     {
         return (new ReflectionClass($instance))->isInstance($var);

--- a/tests/Unit/EventListener/EarlyHintsListenerTest.php
+++ b/tests/Unit/EventListener/EarlyHintsListenerTest.php
@@ -349,8 +349,6 @@ final class EarlyHintsListenerTest extends TestCase
         Request $request,
         int $requestType = HttpKernelInterface::MAIN_REQUEST
     ): RequestEvent {
-        $kernel = $this->createMock(HttpKernelInterface::class);
-
-        return new RequestEvent($kernel, $request, $requestType);
+        return new RequestEvent(static::createStub(HttpKernelInterface::class), $request, $requestType);
     }
 }

--- a/tests/Unit/EventListener/ManifestScreenshotListenerTest.php
+++ b/tests/Unit/EventListener/ManifestScreenshotListenerTest.php
@@ -32,8 +32,8 @@ final class ManifestScreenshotListenerTest extends TestCase
                 'configurations' => [],
             ]);
 
-        $router = $this->createMock(RouterInterface::class);
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $router = static::createStub(RouterInterface::class);
+        $assetMapper = static::createStub(AssetMapperInterface::class);
 
         $listener = new ManifestScreenshotListener($attributeCollector, $router, $assetMapper);
 
@@ -54,8 +54,8 @@ final class ManifestScreenshotListenerTest extends TestCase
                 'configurations' => [],
             ]);
 
-        $router = $this->createMock(RouterInterface::class);
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
+        $router = static::createStub(RouterInterface::class);
+        $assetMapper = static::createStub(AssetMapperInterface::class);
 
         $listener = new ManifestScreenshotListener($attributeCollector, $router, $assetMapper);
 

--- a/tests/Unit/EventListener/ResourceHintsListenerTest.php
+++ b/tests/Unit/EventListener/ResourceHintsListenerTest.php
@@ -301,8 +301,6 @@ final class ResourceHintsListenerTest extends TestCase
         Request $request,
         int $requestType = HttpKernelInterface::MAIN_REQUEST
     ): RequestEvent {
-        $kernel = $this->createMock(HttpKernelInterface::class);
-
-        return new RequestEvent($kernel, $request, $requestType);
+        return new RequestEvent(static::createStub(HttpKernelInterface::class), $request, $requestType);
     }
 }

--- a/tests/Unit/EventListener/ScreenshotListenerTest.php
+++ b/tests/Unit/EventListener/ScreenshotListenerTest.php
@@ -28,7 +28,7 @@ final class ScreenshotListenerTest extends TestCase
 
         $listener = new ScreenshotListener($profiler, 'HeadlessChrome');
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = static::createStub(HttpKernelInterface::class);
         $request = new Request();
         $request->headers->set('user-agent', 'HeadlessChrome/1.0');
 
@@ -46,7 +46,7 @@ final class ScreenshotListenerTest extends TestCase
         // Given
         $listener = new ScreenshotListener(null, 'HeadlessChrome');
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = static::createStub(HttpKernelInterface::class);
         $request = new Request();
         $request->headers->set('user-agent', 'HeadlessChrome/1.0');
 
@@ -69,7 +69,7 @@ final class ScreenshotListenerTest extends TestCase
 
         $listener = new ScreenshotListener($profiler, 'HeadlessChrome');
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = static::createStub(HttpKernelInterface::class);
         $request = new Request();
 
         $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
@@ -90,7 +90,7 @@ final class ScreenshotListenerTest extends TestCase
 
         $listener = new ScreenshotListener($profiler, 'HeadlessChrome');
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = static::createStub(HttpKernelInterface::class);
         $request = new Request();
         $request->headers->set('user-agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
 
@@ -112,7 +112,7 @@ final class ScreenshotListenerTest extends TestCase
 
         $listener = new ScreenshotListener($profiler, 'HeadlessChrome');
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = static::createStub(HttpKernelInterface::class);
         $request = new Request();
         $request->headers->set('user-agent', 'Mozilla/5.0 (X11; Linux x86_64) HeadlessChrome/1.0');
 
@@ -134,7 +134,7 @@ final class ScreenshotListenerTest extends TestCase
 
         $listener = new ScreenshotListener($profiler);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = static::createStub(HttpKernelInterface::class);
         $request = new Request();
         $request->headers->set('user-agent', 'PWAScreenshotBot/1.0');
 
@@ -151,13 +151,13 @@ final class ScreenshotListenerTest extends TestCase
     {
         // Given
         $listener = new ScreenshotListener(null, 'HeadlessChrome');
-        $logger = $this->createMock(LoggerInterface::class);
+        $logger = static::createStub(LoggerInterface::class);
 
         // When
         $listener->setLogger($logger);
 
         // Then
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = static::createStub(HttpKernelInterface::class);
         $request = new Request();
         $request->headers->set('user-agent', 'HeadlessChrome/1.0');
 
@@ -180,7 +180,7 @@ final class ScreenshotListenerTest extends TestCase
 
         $listener->setLogger($logger);
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = static::createStub(HttpKernelInterface::class);
         $request = new Request();
         $request->headers->set('user-agent', 'HeadlessChrome/1.0');
 

--- a/tests/Unit/Normalizer/ScreenshotNormalizerTest.php
+++ b/tests/Unit/Normalizer/ScreenshotNormalizerTest.php
@@ -23,8 +23,8 @@ final class ScreenshotNormalizerTest extends TestCase
     public function itSupportsScreenshotNormalization(): void
     {
         // Given
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+        $assetMapper = static::createStub(AssetMapperInterface::class);
+        $imageProcessor = static::createStub(ImageProcessorInterface::class);
         $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
         $screenshot = new Screenshot();
 
@@ -39,8 +39,8 @@ final class ScreenshotNormalizerTest extends TestCase
     public function itDoesNotSupportOtherTypes(): void
     {
         // Given
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+        $assetMapper = static::createStub(AssetMapperInterface::class);
+        $imageProcessor = static::createStub(ImageProcessorInterface::class);
         $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
         $object = new stdClass();
 
@@ -55,8 +55,8 @@ final class ScreenshotNormalizerTest extends TestCase
     public function itReturnsCorrectSupportedTypes(): void
     {
         // Given
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+        $assetMapper = static::createStub(AssetMapperInterface::class);
+        $imageProcessor = static::createStub(ImageProcessorInterface::class);
         $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
 
         // When
@@ -71,8 +71,8 @@ final class ScreenshotNormalizerTest extends TestCase
     public function itNormalizesScreenshotWithWidthAndHeight(): void
     {
         // Given
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+        $assetMapper = static::createStub(AssetMapperInterface::class);
+        $imageProcessor = static::createStub(ImageProcessorInterface::class);
 
         $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
 
@@ -109,8 +109,8 @@ final class ScreenshotNormalizerTest extends TestCase
     public function itNormalizesScreenshotWithNarrowFormFactor(): void
     {
         // Given
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+        $assetMapper = static::createStub(AssetMapperInterface::class);
+        $imageProcessor = static::createStub(ImageProcessorInterface::class);
 
         $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
 
@@ -138,8 +138,8 @@ final class ScreenshotNormalizerTest extends TestCase
     public function itNormalizesScreenshotWithExplicitFormFactor(): void
     {
         // Given
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+        $assetMapper = static::createStub(AssetMapperInterface::class);
+        $imageProcessor = static::createStub(ImageProcessorInterface::class);
 
         $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
 
@@ -166,8 +166,8 @@ final class ScreenshotNormalizerTest extends TestCase
     public function itNormalizesScreenshotWithoutDimensions(): void
     {
         // Given
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+        $assetMapper = static::createStub(AssetMapperInterface::class);
+        $imageProcessor = static::createStub(ImageProcessorInterface::class);
 
         $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
 
@@ -193,8 +193,8 @@ final class ScreenshotNormalizerTest extends TestCase
     public function itFiltersNullValuesFromResult(): void
     {
         // Given
-        $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+        $assetMapper = static::createStub(AssetMapperInterface::class);
+        $imageProcessor = static::createStub(ImageProcessorInterface::class);
 
         $normalizer = new ScreenshotNormalizer($assetMapper, $imageProcessor);
 
@@ -225,7 +225,7 @@ final class ScreenshotNormalizerTest extends TestCase
     {
         // Given
         $assetMapper = $this->createMock(AssetMapperInterface::class);
-        $imageProcessor = $this->createMock(ImageProcessorInterface::class);
+        $imageProcessor = static::createStub(ImageProcessorInterface::class);
 
         $assetMapper->method('getAsset')
             ->willReturn(null);


### PR DESCRIPTION
## Summary
- The `instanceof` Twig test in `serviceworker-tab.html.twig` (line 148) was failing with "Unknown instanceof test" because `InstanceOfExtension::getTests()` was never called — the class did not extend `AbstractExtension`
- Replaced the `getTests()` method with the `#[AsTwigTest('instanceof')]` attribute, which is properly discovered by Twig's attribute-based service registration (consistent with the existing `#[AsTwigFilter]` and `#[AsTwigFunction]` attributes on the same method)

## Test plan
- [ ] Verify the profiler's service worker tab renders without error when caching strategies have plugins implementing `HasDebugInterface`

🤖 Generated with [Claude Code](https://claude.com/claude-code)