### PR TITLE
Fix Workbox::$config must not be accessed before initialization

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -103,12 +103,6 @@ parameters:
 			path: ../src/Dto/Workbox.php
 
 		-
-			rawMessage: Class SpomkyLabs\PwaBundle\Dto\Workbox has an uninitialized property $config. Give it default value or assign it in the constructor.
-			identifier: property.uninitialized
-			count: 1
-			path: ../src/Dto/Workbox.php
-
-		-
 			rawMessage: Class SpomkyLabs\PwaBundle\Dto\Workbox has an uninitialized property $fontCache. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1

--- a/src/Dto/Workbox.php
+++ b/src/Dto/Workbox.php
@@ -52,5 +52,5 @@ final class Workbox
     #[SerializedName('navigation_preload')]
     public bool $navigationPreload = false;
 
-    public WorkboxConfig $config;
+    public WorkboxConfig $config = new WorkboxConfig();
 }

--- a/src/Dto/Workbox.php
+++ b/src/Dto/Workbox.php
@@ -52,5 +52,10 @@ final class Workbox
     #[SerializedName('navigation_preload')]
     public bool $navigationPreload = false;
 
-    public WorkboxConfig $config = new WorkboxConfig();
+    public WorkboxConfig $config;
+
+    public function __construct()
+    {
+        $this->config = new WorkboxConfig();
+    }
 }


### PR DESCRIPTION
## Summary
- Initialize `Workbox::$config` with `new WorkboxConfig()` default value to prevent "must not be accessed before initialization" error
- Fixes the regression when configuring the service worker with a simple string (`serviceworker: "sw.js"`) without an explicit `workbox.config` section

Fixes #425

## Test plan
- [ ] Verify app works with minimal config: `pwa: { serviceworker: "sw.js" }`
- [ ] Verify app works with explicit workbox config section
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)