### PR TITLE
Fix profiler crash on Workbox service worker tab

### DIFF
--- a/templates/Collector/serviceworker-tab.html.twig
+++ b/templates/Collector/serviceworker-tab.html.twig
@@ -47,8 +47,8 @@
     <tr>
         <td>Use CDN?</td>
         <td>
-            {% if collector.workbox.useCDN %}
-                Yes, version: {{ collector.workbox.version }}
+            {% if collector.workbox.config.useCDN %}
+                Yes, version: {{ collector.workbox.config.version }}
             {% else %}
                 No
             {% endif %}


### PR DESCRIPTION
## Summary
- Fix runtime error in the Symfony profiler service worker tab: `useCDN` and `version` properties were accessed on `Workbox` DTO instead of `Workbox::$config` (`WorkboxConfig`)

## Test plan
- [ ] Open the Symfony profiler service worker tab with Workbox enabled — no more crash
- [ ] Verify CDN status and version display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)